### PR TITLE
updates for point equality and interplay with polyline encoding

### DIFF
--- a/src/midgard/point2.cc
+++ b/src/midgard/point2.cc
@@ -1,6 +1,7 @@
 #include "valhalla/midgard/point2.h"
 
 #include <iostream>
+#include <limits>
 
 #include "valhalla/midgard/util.h"
 #include "valhalla/midgard/vector2.h"
@@ -8,94 +9,83 @@
 namespace valhalla {
 namespace midgard {
 
-Point2::Point2()
-    : x_(0.0f),
-      y_(0.0f) {
-}
-
-Point2::Point2(const float x, const float y)
-    : x_(x),
-      y_(y) {
-}
-
-Point2::Point2(const Point2& p)
-    : x_(p.x_),
-      y_(p.y_) {
-}
-
-Point2& Point2::operator =(const Point2& p) {
-  x_ = p.x_;
-  y_ = p.y_;
-  return *this;
-}
-
 Point2::~Point2() {
 }
 
 float Point2::x() const {
-  return x_;
+  return first;
 }
 
 float Point2::y() const {
-  return y_;
+  return second;
 }
 
 void Point2::set_x(const float x) {
-  x_ = x;
+  first = x;
 }
 
 void Point2::set_y(const float y) {
-  y_ = y;
+  second = y;
 }
 
 void Point2::Set(const float x, const float y) {
-  x_ = x;
-  y_ = y;
+  first = x;
+  second = y;
 }
 
 bool Point2::operator ==(const Point2& p) const {
-  return (x_ == p.x() && y_ == p.y());
+  return (first == p.x() && second == p.y());
 }
 
 bool Point2::operator!=(const Point2& p) const {
-  return (x_ != p.x() || y_ != p.y());
+  return (first != p.x() || second != p.y());
 }
 
 float Point2::DistanceSquared(const Point2& p) const {
-  return sqr(x_ - p.x()) + sqr(y_ - p.y());
+  return sqr(first - p.x()) + sqr(second - p.y());
 }
 
 float Point2::Distance(const Point2& p) const {
-  return sqrtf(sqr(x_ - p.x()) + sqr(y_ - p.y()));
+  return sqrtf(sqr(first - p.x()) + sqr(second - p.y()));
 }
 
 Point2 Point2::AffineCombination(const float a0, const float a1,
                                  const Point2& p1) const {
-  return Point2(a0 * x_ + a1 * p1.x(), a0 * y_ + a1 * p1.y());
+  return Point2(a0 * first + a1 * p1.x(), a0 * second + a1 * p1.y());
 }
 
 Point2 Point2::MidPoint(const Point2& p1) const {
-  return Point2(0.5f * x_ + 0.5f * p1.x(), 0.5f * y_ + 0.5f * p1.y());
+  return Point2(0.5f * first + 0.5f * p1.x(), 0.5f * second + 0.5f * p1.y());
 }
 
 Point2 Point2::operator +(const Vector2& v) const {
-  return Point2(x_ + v.x(), y_ + v.y());
+  return Point2(first + v.x(), second + v.y());
 }
 
 Point2 Point2::operator -(const Vector2& v) const {
-  return Point2(x_ - v.x(), y_ - v.y());
+  return Point2(first - v.x(), second - v.y());
 }
 
 Vector2 Point2::operator -(const Point2& p) const {
-  return Vector2(x_ - p.x(), y_ - p.y());
+  return Vector2(first - p.x(), second - p.y());
 }
 
 float Point2::ClosestPoint(const std::vector<Point2>& pts, Point2& closest,
                            int& idx) const {
-  // TODO - make sure at least 2 points are in list
+
+  float mindist = std::numeric_limits<float>::max();
+  // If there are no points we are done
+  if(pts.size() == 0)
+    return mindist;
+  // If there is one point we are done
+  if(pts.size() == 1) {
+    mindist = DistanceSquared(pts.front());
+    closest = pts.front();
+    idx = 0;
+    return mindist;
+  }
 
   // Iterate through the pts
-  unsigned int count = pts.size();
   bool beyond_end = true;   // Need to test past the end point?
   Vector2 v1;               // Segment vector (v1)
   Vector2 v2;               // Vector from origin to target (v2)
@@ -103,18 +93,19 @@ float Point2::ClosestPoint(const std::vector<Point2>& pts, Point2& closest,
   float dot;                // Dot product of v1 and v2
   float comp;               // Component of v2 along v1
   float dist;   // Squared distance from target to closest point on line
-  float mindist = 2147483647.0f;
-  const Point2* p0 = &pts[0];
-  const Point2* p1 = &pts[1];
-  const Point2* end = &pts[count - 1];
-  for (int index = 0; p1 <= end; index++, p0++, p1++) {
+
+  for (size_t index = 0; index < pts.size() - 1; ++index) {
+    // Get the current segment
+    const Point2& p0 = pts[index];
+    const Point2& p1 = pts[index + 1];
+
     // Construct vector v1 - represents the segment.  Skip 0 length segments
-    v1.Set(*p0, *p1);
+    v1.Set(p0, p1);
     if (v1.x() == 0.0f && v1.y() == 0.0f)
       continue;
 
     // Vector v2 from the segment origin to the target point
-    v2.Set(*p0, *this);
+    v2.Set(p0, *this);
 
     // Find the dot product of v1 and v2.  If less than 0 the segment
     // origin is the closest point.  Find the distance and continue
@@ -122,10 +113,10 @@ float Point2::ClosestPoint(const std::vector<Point2>& pts, Point2& closest,
     dot = v1.Dot(v2);
     if (dot <= 0.0f) {
       beyond_end = false;
-      dist = DistanceSquared(*p0);
+      dist = DistanceSquared(p0);
       if (dist < mindist) {
         mindist = dist;
-        closest = *p0;
+        closest = p0;
         idx = index;
       }
       continue;
@@ -145,7 +136,7 @@ float Point2::ClosestPoint(const std::vector<Point2>& pts, Point2& closest,
       // by adding the projection of v2 onto v1 to the origin point.
       // The squared distance from this point to the target is then found.
       beyond_end = false;
-      projpt = *p0 + v1 * comp;
+      projpt = p0 + v1 * comp;
       dist = DistanceSquared(projpt);
       if (dist < mindist) {
         mindist = dist;
@@ -157,11 +148,11 @@ float Point2::ClosestPoint(const std::vector<Point2>& pts, Point2& closest,
 
   // Test the end point if flag is set - it may be the closest point
   if (beyond_end) {
-    dist = DistanceSquared(*end);
+    dist = DistanceSquared(pts.back());
     if (dist < mindist) {
       mindist = dist;
-      closest = *end;
-      idx = (int) (count - 2);
+      closest = pts.back();
+      idx = static_cast<int>(pts.size() - 2);
     }
   }
   return mindist;

--- a/src/midgard/point2.cc
+++ b/src/midgard/point2.cc
@@ -2,9 +2,14 @@
 
 #include <iostream>
 #include <limits>
+#include <cmath>
 
 #include "valhalla/midgard/util.h"
 #include "valhalla/midgard/vector2.h"
+
+namespace {
+constexpr float EPSILON = .00002f;
+}
 
 namespace valhalla {
 namespace midgard {
@@ -33,13 +38,10 @@ void Point2::Set(const float x, const float y) {
   second = y;
 }
 
-bool Point2::operator ==(const Point2& p) const {
-  return (first == p.x() && second == p.y());
+bool Point2::ApproximatelyEqual(const Point2& p) const {
+  return std::fabs(first - p.x()) < EPSILON && std::fabs(second - p.y()) < EPSILON;
 }
 
-bool Point2::operator!=(const Point2& p) const {
-  return (first != p.x() || second != p.y());
-}
 
 float Point2::DistanceSquared(const Point2& p) const {
   return sqr(first - p.x()) + sqr(second - p.y());

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -1,4 +1,5 @@
 #include "valhalla/midgard/tiles.h"
+#include <cmath>
 
 namespace valhalla {
 namespace midgard {

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -1,4 +1,5 @@
 #include "valhalla/midgard/util.h"
+#include "valhalla/midgard/pointll.h"
 #include "test.h"
 
 #include <boost/format.hpp>
@@ -62,6 +63,12 @@ void TestSimple() {
    * #then generate a test case with python:
    * python -c "import random; import gpolyencode; x = [ [round(random.random() * 180 - 90, 5), round(random.random() * 360 - 180, 5)] for a in range(0, random.randint(1,100)) ]; p = gpolyencode.GPolyEncoder().encode(x)['points']; print; print 'do_pair(' + str(x).replace('[','{').replace(']','}') + ', \"' + repr(p)[1:-1] + '\");'; print"
    */
+
+  //check an easy case first just to be sure Point2/PointLL is working
+  PointLL a(PointLL(1,2));
+  if(encode<std::vector<PointLL> >({{-76.3002, 40.0433}, {-76.3036, 40.043}}) != "s}ksFhkupM|@dT") {
+    throw std::runtime_error("Encoding of Point2/PointLL vector failed");
+  }
 
   //note we are testing with higher precision to avoid truncation/roundoff errors just to make the test cases easier to generate
   do_pair({{-76.60025, 40.49437}}, "y`dvFp~orM");

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -3,7 +3,6 @@
 #include "test.h"
 
 #include <boost/format.hpp>
-#include <cmath>
 
 using namespace std;
 using namespace valhalla::midgard;
@@ -14,17 +13,14 @@ namespace {
 
 using perc_t = double;
 using container_t = std::vector<std::pair<perc_t, perc_t> >;
-constexpr perc_t EPSILON = .00001;
-
-bool appx_equal(const container_t::value_type& a, const container_t::value_type& b) {
-  return abs(a.first - b.first) > EPSILON || abs(a.second - b.second) > EPSILON;
-}
 
 bool appx_equal(const container_t& a, const container_t& b) {
   if(a.size() != b.size())
     return false;
   for(size_t i = 0; i < a.size(); ++i) {
-    if(!appx_equal(a[i], b[i]))
+    const Point2& x = static_cast<const Point2&>(a[i]);
+    const Point2& y = static_cast<const Point2&>(b[i]);
+    if(!x.ApproximatelyEqual(y))
       return false;
   }
   return true;
@@ -47,7 +43,7 @@ void do_pair(const container_t& points, const std::string& encoded) {
   if(enc_answer != encoded)
     throw std::runtime_error("Simple polyline encoding failed. Expected: " + encoded + " Got: " + enc_answer);
   auto dec_answer = decode<container_t>(encoded);
-  if(appx_equal(dec_answer, points))
+  if(!appx_equal(dec_answer, points))
     throw std::runtime_error("Simple polyline decoding failed. Expected: " + to_string(points) + " Got: " + to_string(dec_answer));
   //cant run this thorough of a test due to accumulation of error
   /*if(encode<container_t>(decode<container_t>(encoded)) != encoded)

--- a/valhalla/midgard/point2.h
+++ b/valhalla/midgard/point2.h
@@ -18,30 +18,11 @@ class Vector2;
 class Point2 : public std::pair<float, float>{
 
  public:
-  /**
-   * Default constructor
-   */
-  Point2();
 
   /**
-   * Constructor with initial values for x,y.
-   * @param   x   x coordinate position.
-   * @param   y   y coordinate position.
+   * Use the constructors provided by pair
    */
-  Point2(const float x, const float y);
-
-  /**
-   * Copy constructor.
-   * @param   p   Point to copy to the new point.
-   */
-  Point2(const Point2& p);
-
-  /**
-   * Assignment operator
-   * @param   p   Point to assign to this point.
-   * @return  Returns the address of this point.
-   */
-  Point2& operator = (const Point2& p);
+  using std::pair<float, float>::pair;
 
   /**
    * Destructor
@@ -160,11 +141,6 @@ class Point2 : public std::pair<float, float>{
             int& idx) const;
 
  protected:
-  float x_;
-  float y_;
-
- private:
-
 };
 
 }

--- a/valhalla/midgard/point2.h
+++ b/valhalla/midgard/point2.h
@@ -1,7 +1,6 @@
 #ifndef VALHALLA_MIDGARD_POINT2_H_
 #define VALHALLA_MIDGARD_POINT2_H_
 
-#include <math.h>
 #include <vector>
 #include <utility>
 
@@ -61,19 +60,11 @@ class Point2 : public std::pair<float, float>{
   virtual void Set(const float x, const float y);
 
   /**
-   * Equality operator.
+   * Equality approximation.
    * @param   p  Point to compare to the current point.
-   * @return  Returns true if two points are equal, false otherwise.
+   * @return  Returns true if two points are approximately equal, false otherwise.
    */
-  bool operator == (const Point2& p) const;
-
-  /**
-   * Inequality operator.
-   * @param   p  Point to compare to the current point.
-   * @return  Returns true if the supplied point is not equal to the
-   *          point, false otherwise.
-   */
-  bool operator!= (const Point2& p) const;
+  bool ApproximatelyEqual(const Point2& p) const;
 
   /**
    * Get the distance squared from this point to point p.

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -15,22 +15,14 @@ namespace midgard{
 class PointLL : public Point2 {
  public:
   /**
+   * Use the constructors provided by pair
+   */
+  using Point2::Point2;
+
+  /**
    * Default constructor.  Sets latitude and longitude to INVALID.
    */
   PointLL();
-
-  /**
-   * Constructor using a latitude,longitude pair to initialize.
-   * @param   lng    Longitude in degrees
-   * @param   lat    Latitude in degrees
-   */
-  PointLL(const float lng, const float lat);
-
-  /**
-   * Copy constructor.
-   * @param   ll    Latitude, longitude pair to copy.
-   */
-  PointLL(const PointLL& ll);
 
   /**
    * Get the latitude in degrees.


### PR DESCRIPTION
points got boiled down to an std pair a pr ago. but i had messed up how that worked so that it actually didnt work using the pair. so i've fixed that and added an apprx equals method which is very useful in testing but could be useful for other geometric algorithms. i also fixed up a bit the closest point code to be a little less "c style" looking. all said and done it allowed me to delete a lot of code an really simplify the point classes. this was needed for using the encoding of shape in prs taht i'll add in a minute or two.