### PR TITLE
add logging framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ libvalhalla_midgard.la
 # tests
 test-suite.log
 test-driver
+test/thread_file_log_test.log
 test/point2
 test/linesegment2
 test/distanceapproximator
@@ -50,6 +51,7 @@ test/tiles
 test/aabbll
 test/tilehierarchy
 test/util
+test/logging
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,8 @@ nobase_include_HEADERS = \
 	valhalla/midgard/point2.h \
 	valhalla/midgard/util.h \
 	valhalla/midgard/distanceapproximator.h \
-	valhalla/midgard/ellipse.h
+	valhalla/midgard/ellipse.h \
+	valhalla/midgard/logging.h
 libvalhalla_midgard_la_SOURCES = \
 	src/midgard/linesegment2.cc \
 	src/midgard/tiles.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ libvalhalla_midgard_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS)
 
 # tests
 check_PROGRAMS = \
+	test/logging \
 	test/point2 \
 	test/distanceapproximator \
 	test/aabb2 \
@@ -110,6 +111,10 @@ test_tiles_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_
 test_util_SOURCES = test/util.cc test/test.cc
 test_util_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 test_util_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_midgard.la
+test_logging_SOURCES = test/logging.cc test/test.cc
+test_logging_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@ -DLOGGING_DEBUG
+test_logging_LDFLAGS = -pthread
+test_logging_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ libvalhalla_midgard.la
 
 
 TESTS = $(check_PROGRAMS)

--- a/test/logging.cc
+++ b/test/logging.cc
@@ -1,0 +1,89 @@
+#include "test.h"
+#include "valhalla/midgard/logging.h"
+
+#include <thread>
+#include <future>
+#include <vector>
+#include <functional>
+#include <fstream>
+#include <cstdio>
+#include <algorithm>
+#include <iterator>
+
+using namespace valhalla::midgard;
+
+namespace {
+
+size_t work() {
+  std::ostringstream s; s << "hi my name is: " << std::this_thread::get_id();
+
+  for(size_t i  = 0; i < 2; ++i) {
+    //std::async is pretty uninteresting unless you make things yield
+    LOG_ERROR(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    LOG_WARN(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    LOG_INFO(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    LOG_DEBUG(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    LOG_TRACE(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return 10;
+}
+
+void ThreadFileLoggerTest() {
+  //get rid of it first so we don't append
+  std::remove("test/thread_file_log_test.log");
+
+  //configure logging, if you dont it defaults to standard out logging with colors
+  logging::Configure({ {"type", "file"}, {"file_name", "test/thread_file_log_test.log"}, {"reopen_interval", "1"} });
+
+  //start up some threads
+  std::vector<std::future<size_t> > results;
+  for(size_t i = 0; i < 4; ++i) {
+    results.emplace_back(std::async(std::launch::async, work));
+  }
+
+  //dont really care about the results but we can pretend
+  bool exit_code = 0;
+  for(auto& result : results) {
+    try {
+      size_t count = result.get();
+    }
+    catch(std::exception& e) {
+      std::cout << e.what();
+      exit_code++;
+    }
+  }
+
+  //wait for logger to close and reopen the file
+  std::this_thread::sleep_for(std::chrono::milliseconds(1010));
+  LOG_TRACE("force log close/reopen");
+
+  //open up the file and make sure it looks right
+  std::ifstream file("test/thread_file_log_test.log");
+
+  std::string line;
+  size_t error = 0, warn = 0, info = 0, debug = 0, trace = 0;
+  while(std::getline(file, line)){
+    error += (line.find("ERROR") != std::string::npos);
+    warn += (line.find("WARN") != std::string::npos);
+    info += (line.find("INFO") != std::string::npos);
+    debug += (line.find("DEBUG") != std::string::npos);
+    trace += (line.find("TRACE") != std::string::npos);
+    line.clear();
+  }
+  size_t line_count = error + warn + info + debug + trace;
+  if(line_count != 41)
+    throw std::runtime_error("Log should have exactly 40 lines but had " + std::to_string(line_count));
+  if(error != 8 || warn != 8 || info != 8 || debug != 8 || trace != 9)
+    throw std::runtime_error("Wrong distribution of log messages");
+}
+
+}
+
+int main() {
+  test::suite suite("logging");
+
+  //check file logging
+  suite.test(TEST_CASE(ThreadFileLoggerTest));
+
+  return suite.tear_down();
+}

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -12,35 +12,10 @@
 
 namespace valhalla {
 namespace midgard {
+
 namespace logging {
 
-//a factory that can create Loggers (that derive from 'Logger') via function pointers
-//this way you could make your own Logger that sends log messages to who knows where
-class Logger;
-using LoggerCreator = Logger *(*)(const std::string &);
-class LoggerFactory : 
-    public std::unordered_map<std::string, LoggerCreator> {
- public:
-  Logger* produce(const std::string& config) const {
-    auto found = find(config.substr(0, config.find_first_of(',')));
-    if(found != end()) {
-      return found->second(config);
-    }
-    throw std::runtime_error("Couldn't produce Logger from: " + config);
-  }
-};
-
-static LoggerFactory& GetFactory() {
-  static LoggerFactory factory_singleton{};
-  return factory_singleton;
-}
-
-//register your custom Loggers here
-static bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
-  auto success = GetFactory().emplace(name, function_ptr);
-  return success.second;
-}
-
+//turn a string into a T
 template <class T>
 T atoT(const std::string& input)
 {
@@ -49,7 +24,7 @@ T atoT(const std::string& input)
   stream >> std::ws >> output >> std::ws;
   if(!stream.eof())
     throw std::runtime_error("Couldn't convert string to integral type");
-  return output; 
+  return output;
 }
 
 //returns formated to: 'year/mo/dy hr:mn:sc.xxxxxx'
@@ -57,9 +32,9 @@ std::string TimeStamp() {
   //get the time
   std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
   std::time_t tt = std::chrono::system_clock::to_time_t(tp);
-  std::tm gmt = {0}; gmtime_r(&tt, &gmt);
+  std::tm gmt{}; gmtime_r(&tt, &gmt);
   using sec_t = std::chrono::duration<double>;
-  std::chrono::duration<double> fractional_seconds = 
+  std::chrono::duration<double> fractional_seconds =
     (tp - std::chrono::system_clock::from_time_t(tt)) + std::chrono::seconds(gmt.tm_sec);
   //format the string
   std::string buffer("year/mo/dy hr:mn:sc.xxxxxx");
@@ -68,55 +43,73 @@ std::string TimeStamp() {
   return buffer;
 }
 
-//the log levels we support
-enum class LogLevel : char { TRACE, DEBUG, INFO, WARN, ERROR };
-struct EnumHasher { template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); } };
-
-//returns standard message format: 'timestamp [LOG LEVEL]: message'
-std::string StandardMessage(const std::string& message, const LogLevel level) {
-  std::string output;
-  output.reserve(message.length() + 64);
-  output.append(TimeStamp());
-  switch(level) {
-    case LogLevel::ERROR:
-      output.append(" [ERROR]: ");
-      break;
-    case LogLevel::WARN:
-      output.append(" [WARN]: ");
-      break;
-    case LogLevel::INFO:
-      output.append(" [INFO]: ");
-      break;
-    case LogLevel::DEBUG:
-      output.append(" [DEBUG]: ");
-      break;
-    case LogLevel::TRACE:
-      output.append(" [TRACE]: ");
-      break;
+//a factory that can create loggers (that derive from 'logger') via function pointers
+//this way you could make your own logger that sends log messages to who knows where
+class Logger;
+using LoggingConfig = std::unordered_map<std::string, std::string>;
+using LoggerCreator = Logger *(*)(const LoggingConfig&);
+class LoggerFactory :
+    public std::unordered_map<std::string, LoggerCreator> {
+ public:
+  Logger* Produce(const LoggingConfig& config) const {
+    //grab the type
+    auto type = config.find("type");
+    if(type == config.end())
+      throw std::runtime_error("Logging factory configuration requires a type of logger");
+    //grab the logger
+    auto found = find(type->second);
+    if(found != end())
+      return found->second(config);
+    //couldn't get a logger
+    throw std::runtime_error("Couldn't produce logger for type: " + type->second);
   }
-  output.append(message);
-  output.push_back('\n');
-  return output;
+};
+
+//statically get a factory
+static LoggerFactory& GetFactory() {
+  static LoggerFactory factory_singleton{};
+  return factory_singleton;
 }
 
-//Logger base class, not pure virtual so you can use it has a null Logger if you want
+//register your custom loggers here
+static bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
+  auto success = GetFactory().emplace(name, function_ptr);
+  return success.second;
+}
+
+//the Log levels we support
+enum class LogLevel : char { TRACE, DEBUG, INFO, WARN, ERROR };
+struct EnumHasher { template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); } };
+const std::unordered_map<LogLevel, std::string, EnumHasher> uncolored
+  {
+    {LogLevel::ERROR, " [ERROR] "}, {LogLevel::WARN, " [WARN] "}, {LogLevel::INFO, " [INFO] "},
+    {LogLevel::DEBUG, " [DEBUG] "}, {LogLevel::TRACE, " [TRACE] "}
+  };
+const std::unordered_map<LogLevel, std::string, EnumHasher> colored
+  {
+    {LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "}, {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "},
+    {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "}, {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
+    {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}
+  };
+
+//logger base class, not pure virtual so you can use as a null logger if you want
 class Logger {
  public:
   Logger() = delete;
-  Logger(const std::string& config) {};
+  Logger(const LoggingConfig& config) {};
   virtual ~Logger() {};
   virtual void Log(const std::string&, const LogLevel) {};
  protected:
   std::mutex lock;
 };
 static bool logger_registered = 
-  RegisterLogger("", [](const std::string& config){Logger* l = new Logger(config); return l;});
+  RegisterLogger("", [](const LoggingConfig& config){Logger* l = new Logger(config); return l;});
 
-//Logger that writes to standard out
+//logger that writes to standard out
 class StdOutLogger : public Logger {
  public:
   StdOutLogger() = delete;
-  StdOutLogger(const std::string& config):Logger(config),levels(GetLogDirectives(config)) {}
+  StdOutLogger(const LoggingConfig& config) : Logger(config),levels(config.find("color") != config.end() ? colored : uncolored) {}
   virtual void Log(const std::string& message, const LogLevel level) {
     std::string output;
     output.reserve(message.length() + 64);
@@ -127,65 +120,56 @@ class StdOutLogger : public Logger {
     //cout is thread safe, to avoid multiple threads interleaving on one line
     //though, we make sure to only call the << operator once on std::cout
     //otherwise the << operators from different threads could interleave
+    //obviously we dont care if flushes interleave
     std::cout << output;
+    std::cout.flush();
   }
  protected:
-  static std::unordered_map<LogLevel, std::string, EnumHasher> GetLogDirectives(const std::string& config) {
-    //if it not colored don't use color
-    auto pos = config.find_first_of(',');
-    if(pos == std::string::npos || pos == config.length() - 1 || config.substr(pos + 1) != "color")
-      return {{LogLevel::ERROR, " [ERROR] "}, {LogLevel::WARN, " [WARN] "}, {LogLevel::INFO, " [INFO] "}, 
-        {LogLevel::DEBUG, " [DEBUG] "}, {LogLevel::TRACE, " [TRACE] "} };
-    //use color
-    return {{LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "}, {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "}, 
-      {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "}, {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "}, 
-      {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "} };
-  }
   const std::unordered_map<LogLevel, std::string, EnumHasher> levels;
 };
 static bool std_out_logger_registered = 
-  RegisterLogger("std_out", [](const std::string& config){Logger* l = new StdOutLogger(config); return l;});
+  RegisterLogger("std_out", [](const LoggingConfig& config){Logger* l = new StdOutLogger(config); return l;});
 
-//TODO: add reopen interval
 //TODO: add log rolling
-//Logger that writes to file
+//logger that writes to file
 class FileLogger : public Logger {
  public:
   FileLogger() = delete;
-  FileLogger(const std::string& config):Logger(config) {
+  FileLogger(const LoggingConfig& config):Logger(config) {
     //grab the file name
-    auto pos = config.find_first_of(',');
-    if(pos == std::string::npos || pos == config.length() - 1)
-      throw std::runtime_error("No output file provided to file Logger");
-    file_name = config.substr(++pos);
+    auto name = config.find("file_name");
+    if(name == config.end())
+      throw std::runtime_error("No output file provided to file logger");
+    file_name = name->second;
     
     //if we specify an interval
     reopen_interval = std::chrono::seconds(300);
-    pos = file_name.find_first_of(',', pos);
-    if(pos != std::string::npos && pos != config.length() - 1)
+    auto interval = config.find("reopen_interval");
+    if(interval != config.end())
     {
-      auto interval = file_name.substr(pos + 1);
-      file_name.resize(pos);
       try {        
-        reopen_interval = std::chrono::seconds(atoT<int>(interval));
+        reopen_interval = std::chrono::seconds(atoT<int>(interval->second));
       }
       catch(...) {
-        throw std::runtime_error(interval + " is not a valid reopen interval");
+        throw std::runtime_error(interval->second + " is not a valid reopen interval");
       }
     }
     
     //crack the file open
     ReOpen();
   }
-  virtual ~FileLogger() {
-    try{ file.close(); }catch(...){}
-  }
   virtual void Log(const std::string& message, const LogLevel level) {
-    std::string output(StandardMessage(message, level));
+    std::string output;
+    output.reserve(message.length() + 64);
+    output.append(TimeStamp());
+    output.append(uncolored.find(level)->second);
+    output.append(message);
+    output.push_back('\n');
     lock.lock();
     file << output;
+    file.flush();
     lock.unlock();
-    ReOpen();    
+    ReOpen();
   }
  protected:
   void ReOpen() {
@@ -213,14 +197,16 @@ class FileLogger : public Logger {
   std::chrono::system_clock::time_point last_reopen;
 };
 static bool file_logger_registered = 
-  RegisterLogger("file", [](const std::string& config){Logger* l = new FileLogger(config); return l;});
+  RegisterLogger("file", [](const LoggingConfig& config){Logger* l = new FileLogger(config); return l;});
 
-static Logger& GetLogger(const std::string& config = "std_out,color") {
-  static std::unique_ptr<Logger> singleton(GetFactory().produce(config));
+//statically get a logger using the factory
+static Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", ""} }) {
+  static std::unique_ptr<Logger> singleton(GetFactory().Produce(config));
   return *singleton;
 }
 
-static void Configure(const std::string& config) {
+//statically configure logging
+static void Configure(const LoggingConfig& config) {
   GetLogger(config);
 }
 
@@ -237,48 +223,6 @@ static void Configure(const std::string& config) {
 #define LOG_ERROR(x) ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::ERROR);
 
 }
-}
-}
 
-#include <thread>
-#include <future>
-#include <vector>
-#include <functional>
-
-size_t work() {
-  std::ostringstream s; s << "hi my name is: " << std::this_thread::get_id();
-  
-  for(size_t i  = 0; i < 2; ++i) {
-    //std::async is pretty uninteresting unless you make things yield
-    LOG_ERROR(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    LOG_WARN(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    LOG_INFO(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    LOG_DEBUG(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    LOG_TRACE(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  }
-  return 10;
 }
-
-int main(void) {
-  //configure logging, if you dont it defaults to standard out logging with colors
-  //valhalla::midgard::logging::Configure("file,test.log,1");
-  
-  //start up some threads
-  std::vector<std::future<size_t> > results;
-  for(size_t i = 0; i < 4; ++i) {
-    results.emplace_back(std::async(std::launch::async, work));
-  }
-  
-  //dont really care about the results but we can pretend
-  bool exit_code = 0;
-  for(auto& result : results) {
-    try {
-      size_t count = result.get();
-    }
-    catch(std::exception& e) {
-      std::cout << e.what();
-      exit_code++;
-    }
-  }
-  return exit_code;
 }

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -160,7 +160,7 @@ class FileLogger : public Logger {
     file_name = config.substr(++pos);
     
     //if we specify an interval
-    reopen_interval = std::chrono::seconds(10);
+    reopen_interval = std::chrono::seconds(300);
     pos = file_name.find_first_of(',', pos);
     if(pos != std::string::npos && pos != config.length() - 1)
     {

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -1,0 +1,284 @@
+#include <string>
+#include <stdexcept>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <mutex>
+#include <unordered_map>
+#include <memory>
+#include <chrono>
+#include <ctime>
+#include <cstdlib>
+
+namespace valhalla {
+namespace midgard {
+namespace logging {
+
+//a factory that can create Loggers (that derive from 'Logger') via function pointers
+//this way you could make your own Logger that sends log messages to who knows where
+class Logger;
+using LoggerCreator = Logger *(*)(const std::string &);
+class LoggerFactory : 
+    public std::unordered_map<std::string, LoggerCreator> {
+ public:
+  Logger* produce(const std::string& config) const {
+    auto found = find(config.substr(0, config.find_first_of(',')));
+    if(found != end()) {
+      return found->second(config);
+    }
+    throw std::runtime_error("Couldn't produce Logger from: " + config);
+  }
+};
+
+static LoggerFactory& GetFactory() {
+  static LoggerFactory factory_singleton{};
+  return factory_singleton;
+}
+
+//register your custom Loggers here
+static bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
+  auto success = GetFactory().emplace(name, function_ptr);
+  return success.second;
+}
+
+template <class T>
+T atoT(const std::string& input)
+{
+  std::istringstream stream(input);
+  T output;
+  stream >> std::ws >> output >> std::ws;
+  if(!stream.eof())
+    throw std::runtime_error("Couldn't convert string to integral type");
+  return output; 
+}
+
+//returns formated to: 'year/mo/dy hr:mn:sc.xxxxxx'
+std::string TimeStamp() {
+  //get the time
+  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
+  std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+  std::tm gmt = {0}; gmtime_r(&tt, &gmt);
+  using sec_t = std::chrono::duration<double>;
+  std::chrono::duration<double> fractional_seconds = 
+    (tp - std::chrono::system_clock::from_time_t(tt)) + std::chrono::seconds(gmt.tm_sec);
+  //format the string
+  std::string buffer("year/mo/dy hr:mn:sc.xxxxxx");
+  sprintf(&buffer.front(), "%04d/%02d/%02d %02d:%02d:%09f.6", gmt.tm_year + 1900, gmt.tm_mon + 1,
+    gmt.tm_mday, gmt.tm_hour, gmt.tm_min, fractional_seconds.count());
+  return buffer;
+}
+
+//the log levels we support
+enum class LogLevel : char { TRACE, DEBUG, INFO, WARN, ERROR };
+struct EnumHasher { template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); } };
+
+//returns standard message format: 'timestamp [LOG LEVEL]: message'
+std::string StandardMessage(const std::string& message, const LogLevel level) {
+  std::string output;
+  output.reserve(message.length() + 64);
+  output.append(TimeStamp());
+  switch(level) {
+    case LogLevel::ERROR:
+      output.append(" [ERROR]: ");
+      break;
+    case LogLevel::WARN:
+      output.append(" [WARN]: ");
+      break;
+    case LogLevel::INFO:
+      output.append(" [INFO]: ");
+      break;
+    case LogLevel::DEBUG:
+      output.append(" [DEBUG]: ");
+      break;
+    case LogLevel::TRACE:
+      output.append(" [TRACE]: ");
+      break;
+  }
+  output.append(message);
+  output.push_back('\n');
+  return output;
+}
+
+//Logger base class, not pure virtual so you can use it has a null Logger if you want
+class Logger {
+ public:
+  Logger() = delete;
+  Logger(const std::string& config) {};
+  virtual ~Logger() {};
+  virtual void Log(const std::string&, const LogLevel) {};
+ protected:
+  std::mutex lock;
+};
+static bool logger_registered = 
+  RegisterLogger("", [](const std::string& config){Logger* l = new Logger(config); return l;});
+
+//Logger that writes to standard out
+class StdOutLogger : public Logger {
+ public:
+  StdOutLogger() = delete;
+  StdOutLogger(const std::string& config):Logger(config),levels(GetLogDirectives(config)) {}
+  virtual void Log(const std::string& message, const LogLevel level) {
+    std::string output;
+    output.reserve(message.length() + 64);
+    output.append(TimeStamp());
+    output.append(levels.find(level)->second);
+    output.append(message);
+    output.push_back('\n');
+    //cout is thread safe, to avoid multiple threads interleaving on one line
+    //though, we make sure to only call the << operator once on std::cout
+    //otherwise the << operators from different threads could interleave
+    std::cout << output;
+  }
+ protected:
+  static std::unordered_map<LogLevel, std::string, EnumHasher> GetLogDirectives(const std::string& config) {
+    //if it not colored don't use color
+    auto pos = config.find_first_of(',');
+    if(pos == std::string::npos || pos == config.length() - 1 || config.substr(pos + 1) != "color")
+      return {{LogLevel::ERROR, " [ERROR] "}, {LogLevel::WARN, " [WARN] "}, {LogLevel::INFO, " [INFO] "}, 
+        {LogLevel::DEBUG, " [DEBUG] "}, {LogLevel::TRACE, " [TRACE] "} };
+    //use color
+    return {{LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "}, {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "}, 
+      {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "}, {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "}, 
+      {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "} };
+  }
+  const std::unordered_map<LogLevel, std::string, EnumHasher> levels;
+};
+static bool std_out_logger_registered = 
+  RegisterLogger("std_out", [](const std::string& config){Logger* l = new StdOutLogger(config); return l;});
+
+//TODO: add reopen interval
+//TODO: add log rolling
+//Logger that writes to file
+class FileLogger : public Logger {
+ public:
+  FileLogger() = delete;
+  FileLogger(const std::string& config):Logger(config) {
+    //grab the file name
+    auto pos = config.find_first_of(',');
+    if(pos == std::string::npos || pos == config.length() - 1)
+      throw std::runtime_error("No output file provided to file Logger");
+    file_name = config.substr(++pos);
+    
+    //if we specify an interval
+    reopen_interval = std::chrono::seconds(10);
+    pos = file_name.find_first_of(',', pos);
+    if(pos != std::string::npos && pos != config.length() - 1)
+    {
+      auto interval = file_name.substr(pos + 1);
+      file_name.resize(pos);
+      try {        
+        reopen_interval = std::chrono::seconds(atoT<int>(interval));
+      }
+      catch(...) {
+        throw std::runtime_error(interval + " is not a valid reopen interval");
+      }
+    }
+    
+    //crack the file open
+    ReOpen();
+  }
+  virtual ~FileLogger() {
+    try{ file.close(); }catch(...){}
+  }
+  virtual void Log(const std::string& message, const LogLevel level) {
+    std::string output(StandardMessage(message, level));
+    lock.lock();
+    file << output;
+    lock.unlock();
+    ReOpen();    
+  }
+ protected:
+  void ReOpen() {
+    //TODO: use CLOCK_MONOTONIC_COARSE
+    //check if it should be closed and reopened
+    auto now = std::chrono::system_clock::now();
+    lock.lock();
+    if(now - last_reopen > reopen_interval) {
+      last_reopen = now;
+      try{ file.close(); }catch(...){}
+      try {
+        file.open(file_name, std::ofstream::out | std::ofstream::app);
+        last_reopen = std::chrono::system_clock::now();
+      }
+      catch(std::exception& e) {
+        try{ file.close(); }catch(...){}
+        throw e;
+      }
+    }    
+    lock.unlock();
+  }
+  std::string file_name;
+  std::ofstream file;
+  std::chrono::seconds reopen_interval;
+  std::chrono::system_clock::time_point last_reopen;
+};
+static bool file_logger_registered = 
+  RegisterLogger("file", [](const std::string& config){Logger* l = new FileLogger(config); return l;});
+
+static Logger& GetLogger(const std::string& config = "std_out,color") {
+  static std::unique_ptr<Logger> singleton(GetFactory().produce(config));
+  return *singleton;
+}
+
+static void Configure(const std::string& config) {
+  GetLogger(config);
+}
+
+//convenience macros stand out when reading code
+#ifndef LOGGING_DEBUG 
+#define LOG_TRACE(x)
+#define LOG_DEBUG(x)
+#else
+#define LOG_TRACE(x) ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::TRACE);
+#define LOG_DEBUG(x) ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::DEBUG);
+#endif
+#define LOG_INFO(x)  ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::INFO);
+#define LOG_WARN(x)  ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::WARN);
+#define LOG_ERROR(x) ::valhalla::midgard::logging::GetLogger().Log(x, ::valhalla::midgard::logging::LogLevel::ERROR);
+
+}
+}
+}
+
+#include <thread>
+#include <future>
+#include <vector>
+#include <functional>
+
+size_t work() {
+  std::ostringstream s; s << "hi my name is: " << std::this_thread::get_id();
+  
+  for(size_t i  = 0; i < 2; ++i) {
+    //std::async is pretty uninteresting unless you make things yield
+    LOG_ERROR(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    LOG_WARN(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    LOG_INFO(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    LOG_DEBUG(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    LOG_TRACE(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+  return 10;
+}
+
+int main(void) {
+  //configure logging, if you dont it defaults to standard out logging with colors
+  //valhalla::midgard::logging::Configure("file,test.log,1");
+  
+  //start up some threads
+  std::vector<std::future<size_t> > results;
+  for(size_t i = 0; i < 4; ++i) {
+    results.emplace_back(std::async(std::launch::async, work));
+  }
+  
+  //dont really care about the results but we can pretend
+  bool exit_code = 0;
+  for(auto& result : results) {
+    try {
+      size_t count = result.get();
+    }
+    catch(std::exception& e) {
+      std::cout << e.what();
+      exit_code++;
+    }
+  }
+  return exit_code;
+}


### PR DESCRIPTION
this logger is thread safe and allows you to log to stdout with pretty colors or to file. stdout is already thread safe so not much care was needed there. the file mechanism is not and therefore needed mutexs to synchronize. also the file logger needs to be configured to close and reopen the file on a regular interval. this is useful because if the program segfaults you dont get anything in your file log if you dont periodically close it and reopen it. the default config is for it to do this every 5 minutes. there are really only two interfaces to the whole framework that you need.

1. at the beginning of your program configure logging, after you do this you can never configure it again some example would be:
    //write log output to the file test.log and reopen the file ever 60 sec
    logging::configure("file,test.log,60");
    //write log output to the screen and make it colorful
    logging::configure("std_out,color");

2. after that you can log by doing this:
    LOG_ERROR("some std::string or literal")
    LOG_WARN("some std::string or literal")
    LOG_INFO("some std::string or literal")
    LOG_DEBUG("some std::string or literal")
    LOG_TRACE("some std::string or literal")

3. if you do want to enable LOG_DEBUG and LOG_TRACE you must do so by passing CXXFLAGS=-DLOGGING_DEBUG to configure for example
