### PR TITLE
logger fixes for using accross multiple files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,8 @@ libvalhalla_midgard_la_SOURCES = \
 	src/midgard/point2.cc \
 	src/midgard/util.cc \
 	src/midgard/distanceapproximator.cc \
-	src/midgard/ellipse.cc
+	src/midgard/ellipse.cc \
+	src/midgard/logging.cc
 libvalhalla_midgard_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_midgard_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS)
 

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -1,0 +1,199 @@
+#include "midgard/logging.h"
+
+#include <stdexcept>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <memory>
+#include <chrono>
+#include <ctime>
+#include <cstdlib>
+
+namespace {
+
+//returns formated to: 'year/mo/dy hr:mn:sc.xxxxxx'
+std::string TimeStamp() {
+  //get the time
+  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
+  std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+  std::tm gmt{}; gmtime_r(&tt, &gmt);
+  using sec_t = std::chrono::duration<double>;
+  std::chrono::duration<double> fractional_seconds =
+    (tp - std::chrono::system_clock::from_time_t(tt)) + std::chrono::seconds(gmt.tm_sec);
+  //format the string
+  std::string buffer("year/mo/dy hr:mn:sc.xxxxxx");
+  sprintf(&buffer.front(), "%04d/%02d/%02d %02d:%02d:%09f.6", gmt.tm_year + 1900, gmt.tm_mon + 1,
+    gmt.tm_mday, gmt.tm_hour, gmt.tm_min, fractional_seconds.count());
+  return buffer;
+}
+
+}
+
+namespace valhalla {
+namespace midgard {
+
+namespace logging {
+
+
+//a factory that can create loggers (that derive from 'logger') via function pointers
+//this way you could make your own logger that sends log messages to who knows where
+Logger* LoggerFactory::Produce(const LoggingConfig& config) const {
+  //grab the type
+  auto type = config.find("type");
+  if(type == config.end())
+    throw std::runtime_error("Logging factory configuration requires a type of logger");
+  //grab the logger
+  auto found = find(type->second);
+  if(found != end())
+    return found->second(config);
+  //couldn't get a logger
+  throw std::runtime_error("Couldn't produce logger for type: " + type->second);
+}
+
+//statically get a factory
+LoggerFactory& GetFactory() {
+  static LoggerFactory factory_singleton{};
+  return factory_singleton;
+}
+
+//register your custom loggers here
+bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
+  auto success = GetFactory().emplace(name, function_ptr);
+  return success.second;
+}
+
+//the Log levels we support
+struct EnumHasher { template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); } };
+const std::unordered_map<LogLevel, std::string, EnumHasher> uncolored
+  {
+    {LogLevel::ERROR, " [ERROR] "}, {LogLevel::WARN, " [WARN] "}, {LogLevel::INFO, " [INFO] "},
+    {LogLevel::DEBUG, " [DEBUG] "}, {LogLevel::TRACE, " [TRACE] "}
+  };
+const std::unordered_map<LogLevel, std::string, EnumHasher> colored
+  {
+    {LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "}, {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "},
+    {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "}, {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
+    {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}
+  };
+
+
+//logger base class, not pure virtual so you can use as a null logger if you want
+Logger::Logger(const LoggingConfig& config) {};
+Logger::~Logger() {};
+void Logger::Log(const std::string&, const LogLevel) {};
+bool logger_registered =
+  RegisterLogger("", [](const LoggingConfig& config){Logger* l = new Logger(config); return l;});
+
+//logger that writes to standard out
+class StdOutLogger : public Logger {
+ public:
+  StdOutLogger() = delete;
+  StdOutLogger(const LoggingConfig& config) : Logger(config),levels(config.find("color") != config.end() ? colored : uncolored) {}
+  virtual void Log(const std::string& message, const LogLevel level) {
+    std::string output;
+    output.reserve(message.length() + 64);
+    output.append(TimeStamp());
+    output.append(levels.find(level)->second);
+    output.append(message);
+    output.push_back('\n');
+    //cout is thread safe, to avoid multiple threads interleaving on one line
+    //though, we make sure to only call the << operator once on std::cout
+    //otherwise the << operators from different threads could interleave
+    //obviously we dont care if flushes interleave
+    std::cout << output;
+    std::cout.flush();
+  }
+ protected:
+  const std::unordered_map<LogLevel, std::string, EnumHasher> levels;
+};
+bool std_out_logger_registered =
+  RegisterLogger("std_out", [](const LoggingConfig& config){Logger* l = new StdOutLogger(config); return l;});
+
+//TODO: add log rolling
+//logger that writes to file
+class FileLogger : public Logger {
+ public:
+  FileLogger() = delete;
+  FileLogger(const LoggingConfig& config):Logger(config) {
+    //grab the file name
+    auto name = config.find("file_name");
+    if(name == config.end())
+      throw std::runtime_error("No output file provided to file logger");
+    file_name = name->second;
+    
+    //if we specify an interval
+    reopen_interval = std::chrono::seconds(300);
+    auto interval = config.find("reopen_interval");
+    if(interval != config.end())
+    {
+      try {        
+        reopen_interval = std::chrono::seconds(std::stoul(interval->second));
+      }
+      catch(...) {
+        throw std::runtime_error(interval->second + " is not a valid reopen interval");
+      }
+    }
+    
+    //crack the file open
+    ReOpen();
+  }
+  virtual void Log(const std::string& message, const LogLevel level) {
+    std::string output;
+    output.reserve(message.length() + 64);
+    output.append(TimeStamp());
+    output.append(uncolored.find(level)->second);
+    output.append(message);
+    output.push_back('\n');
+    lock.lock();
+    file << output;
+    file.flush();
+    lock.unlock();
+    ReOpen();
+  }
+ protected:
+  void ReOpen() {
+    //TODO: use CLOCK_MONOTONIC_COARSE
+    //check if it should be closed and reopened
+    auto now = std::chrono::system_clock::now();
+    lock.lock();
+    if(now - last_reopen > reopen_interval) {
+      last_reopen = now;
+      try{ file.close(); }catch(...){}
+      try {
+        file.open(file_name, std::ofstream::out | std::ofstream::app);
+        last_reopen = std::chrono::system_clock::now();
+      }
+      catch(std::exception& e) {
+        try{ file.close(); }catch(...){}
+        throw e;
+      }
+    }    
+    lock.unlock();
+  }
+  std::string file_name;
+  std::ofstream file;
+  std::chrono::seconds reopen_interval;
+  std::chrono::system_clock::time_point last_reopen;
+};
+bool file_logger_registered =
+  RegisterLogger("file", [](const LoggingConfig& config){Logger* l = new FileLogger(config); return l;});
+
+}
+
+//statically get a logger using the factory
+logging::Logger& logging::GetLogger(const LoggingConfig& config) {
+  static std::unique_ptr<Logger> singleton(GetFactory().Produce(config));
+  return *singleton;
+}
+
+//statically configure logging
+void logging::Configure(const LoggingConfig& config) {
+  GetLogger(config);
+}
+
+}
+}
+
+
+
+

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -88,7 +88,7 @@ bool logger_registered =
 class StdOutLogger : public Logger {
  public:
   StdOutLogger() = delete;
-  StdOutLogger(const LoggingConfig& config) : Logger(config),levels(config.find("color") != config.end() ? colored : uncolored) {}
+  StdOutLogger(const LoggingConfig& config) : Logger(config), levels(config.find("color") != config.end() && config.find("color")->second == "true" ? colored : uncolored) {}
   virtual void Log(const std::string& message, const LogLevel level) {
     std::string output;
     output.reserve(message.length() + 64);

--- a/test/logging.cc
+++ b/test/logging.cc
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <algorithm>
 #include <iterator>
+#include <sstream>
 
 using namespace valhalla::midgard;
 

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -1,3 +1,6 @@
+#ifndef VALHALLA_MIDGARD_LOGGING_H_
+#define VALHALLA_MIDGARD_LOGGING_H_
+
 #include <string>
 #include <stdexcept>
 #include <iostream>
@@ -274,3 +277,5 @@ static void Configure(const LoggingConfig& config) {
 
 }
 }
+
+#endif

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -39,7 +39,7 @@ class Logger {
 };
 
 //statically get a logger using the factory
-Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", ""} });
+Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", "true"} });
 
 //statically configure logging
 //try something like:

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -2,37 +2,13 @@
 #define VALHALLA_MIDGARD_LOGGING_H_
 
 #include <string>
-#include <stdexcept>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 #include <mutex>
 #include <unordered_map>
-#include <memory>
-#include <chrono>
-#include <ctime>
-#include <cstdlib>
 
 namespace valhalla {
 namespace midgard {
 
 namespace logging {
-
-//returns formated to: 'year/mo/dy hr:mn:sc.xxxxxx'
-std::string TimeStamp() {
-  //get the time
-  std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
-  std::time_t tt = std::chrono::system_clock::to_time_t(tp);
-  std::tm gmt{}; gmtime_r(&tt, &gmt);
-  using sec_t = std::chrono::duration<double>;
-  std::chrono::duration<double> fractional_seconds =
-    (tp - std::chrono::system_clock::from_time_t(tt)) + std::chrono::seconds(gmt.tm_sec);
-  //format the string
-  std::string buffer("year/mo/dy hr:mn:sc.xxxxxx");
-  sprintf(&buffer.front(), "%04d/%02d/%02d %02d:%02d:%09f.6", gmt.tm_year + 1900, gmt.tm_mon + 1,
-    gmt.tm_mday, gmt.tm_hour, gmt.tm_min, fractional_seconds.count());
-  return buffer;
-}
 
 //a factory that can create loggers (that derive from 'logger') via function pointers
 //this way you could make your own logger that sends log messages to who knows where
@@ -42,164 +18,34 @@ using LoggerCreator = Logger *(*)(const LoggingConfig&);
 class LoggerFactory :
     public std::unordered_map<std::string, LoggerCreator> {
  public:
-  Logger* Produce(const LoggingConfig& config) const {
-    //grab the type
-    auto type = config.find("type");
-    if(type == config.end())
-      throw std::runtime_error("Logging factory configuration requires a type of logger");
-    //grab the logger
-    auto found = find(type->second);
-    if(found != end())
-      return found->second(config);
-    //couldn't get a logger
-    throw std::runtime_error("Couldn't produce logger for type: " + type->second);
-  }
+  Logger* Produce(const LoggingConfig& config) const;
 };
 
-//statically get a factory
-static LoggerFactory& GetFactory() {
-  static LoggerFactory factory_singleton{};
-  return factory_singleton;
-}
-
 //register your custom loggers here
-static bool RegisterLogger(const std::string& name, LoggerCreator function_ptr) {
-  auto success = GetFactory().emplace(name, function_ptr);
-  return success.second;
-}
+bool RegisterLogger(const std::string& name, LoggerCreator function_ptr);
 
 //the Log levels we support
 enum class LogLevel : char { TRACE, DEBUG, INFO, WARN, ERROR };
-struct EnumHasher { template <typename T> std::size_t operator()(T t) const { return static_cast<std::size_t>(t); } };
-const std::unordered_map<LogLevel, std::string, EnumHasher> uncolored
-  {
-    {LogLevel::ERROR, " [ERROR] "}, {LogLevel::WARN, " [WARN] "}, {LogLevel::INFO, " [INFO] "},
-    {LogLevel::DEBUG, " [DEBUG] "}, {LogLevel::TRACE, " [TRACE] "}
-  };
-const std::unordered_map<LogLevel, std::string, EnumHasher> colored
-  {
-    {LogLevel::ERROR, " \x1b[31;1m[ERROR]\x1b[0m "}, {LogLevel::WARN, " \x1b[33;1m[WARN]\x1b[0m "},
-    {LogLevel::INFO, " \x1b[32;1m[INFO]\x1b[0m "}, {LogLevel::DEBUG, " \x1b[34;1m[DEBUG]\x1b[0m "},
-    {LogLevel::TRACE, " \x1b[37;1m[TRACE]\x1b[0m "}
-  };
 
 //logger base class, not pure virtual so you can use as a null logger if you want
 class Logger {
  public:
   Logger() = delete;
-  Logger(const LoggingConfig& config) {};
-  virtual ~Logger() {};
-  virtual void Log(const std::string&, const LogLevel) {};
+  Logger(const LoggingConfig& config);
+  virtual ~Logger();
+  virtual void Log(const std::string&, const LogLevel);
  protected:
   std::mutex lock;
 };
-static bool logger_registered = 
-  RegisterLogger("", [](const LoggingConfig& config){Logger* l = new Logger(config); return l;});
-
-//logger that writes to standard out
-class StdOutLogger : public Logger {
- public:
-  StdOutLogger() = delete;
-  StdOutLogger(const LoggingConfig& config) : Logger(config),levels(config.find("color") != config.end() ? colored : uncolored) {}
-  virtual void Log(const std::string& message, const LogLevel level) {
-    std::string output;
-    output.reserve(message.length() + 64);
-    output.append(TimeStamp());
-    output.append(levels.find(level)->second);
-    output.append(message);
-    output.push_back('\n');
-    //cout is thread safe, to avoid multiple threads interleaving on one line
-    //though, we make sure to only call the << operator once on std::cout
-    //otherwise the << operators from different threads could interleave
-    //obviously we dont care if flushes interleave
-    std::cout << output;
-    std::cout.flush();
-  }
- protected:
-  const std::unordered_map<LogLevel, std::string, EnumHasher> levels;
-};
-static bool std_out_logger_registered = 
-  RegisterLogger("std_out", [](const LoggingConfig& config){Logger* l = new StdOutLogger(config); return l;});
-
-//TODO: add log rolling
-//logger that writes to file
-class FileLogger : public Logger {
- public:
-  FileLogger() = delete;
-  FileLogger(const LoggingConfig& config):Logger(config) {
-    //grab the file name
-    auto name = config.find("file_name");
-    if(name == config.end())
-      throw std::runtime_error("No output file provided to file logger");
-    file_name = name->second;
-    
-    //if we specify an interval
-    reopen_interval = std::chrono::seconds(300);
-    auto interval = config.find("reopen_interval");
-    if(interval != config.end())
-    {
-      try {        
-        reopen_interval = std::chrono::seconds(std::stoul(interval->second));
-      }
-      catch(...) {
-        throw std::runtime_error(interval->second + " is not a valid reopen interval");
-      }
-    }
-    
-    //crack the file open
-    ReOpen();
-  }
-  virtual void Log(const std::string& message, const LogLevel level) {
-    std::string output;
-    output.reserve(message.length() + 64);
-    output.append(TimeStamp());
-    output.append(uncolored.find(level)->second);
-    output.append(message);
-    output.push_back('\n');
-    lock.lock();
-    file << output;
-    file.flush();
-    lock.unlock();
-    ReOpen();
-  }
- protected:
-  void ReOpen() {
-    //TODO: use CLOCK_MONOTONIC_COARSE
-    //check if it should be closed and reopened
-    auto now = std::chrono::system_clock::now();
-    lock.lock();
-    if(now - last_reopen > reopen_interval) {
-      last_reopen = now;
-      try{ file.close(); }catch(...){}
-      try {
-        file.open(file_name, std::ofstream::out | std::ofstream::app);
-        last_reopen = std::chrono::system_clock::now();
-      }
-      catch(std::exception& e) {
-        try{ file.close(); }catch(...){}
-        throw e;
-      }
-    }    
-    lock.unlock();
-  }
-  std::string file_name;
-  std::ofstream file;
-  std::chrono::seconds reopen_interval;
-  std::chrono::system_clock::time_point last_reopen;
-};
-static bool file_logger_registered = 
-  RegisterLogger("file", [](const LoggingConfig& config){Logger* l = new FileLogger(config); return l;});
 
 //statically get a logger using the factory
-static Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", ""} }) {
-  static std::unique_ptr<Logger> singleton(GetFactory().Produce(config));
-  return *singleton;
-}
+Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", ""} });
 
 //statically configure logging
-static void Configure(const LoggingConfig& config) {
-  GetLogger(config);
-}
+//try something like:
+//logging::Configure({ {"type", "std_out"}, {"color", ""} })
+//logging::Configure({ {"type", "file"}, {"file_name", "test.log"}, {"reopen_interval", "1"} })
+void Configure(const LoggingConfig& config);
 
 //convenience macros stand out when reading code
 //default to seeing INFO and up if nothing was specified

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -79,6 +79,20 @@ std::string encode(const container_t& points);
 template<class container_t>
 container_t decode(const std::string& encoded);
 
+//useful in converting from one iteratable map to another
+//for example: ToMap<boost::property_tree::ptree, std::unordered_map<std::string, std::string> >(some_ptree)
+/*
+ * @param inmap the map to be converted
+ * @return the converted map of another type
+ */
+template <class T1, class T2>
+T2 ToMap(const T1& inmap) {
+  T2 outmap;
+  for(const auto& key_value : inmap)
+    outmap[key_value.first] = key_value.second.data();
+  return outmap;
+}
+
 }
 }
 #endif  // VALHALLA_MIDGARD_UTIL_H_


### PR DESCRIPTION
~~this sucks. i want the logger to be header only so that each project can configure it seprately however this turns out to not make any sense. if a singleton lives in a header only and a downstream library initializes it what happens in the upstream? my brain hurts and this makes it work so we'll have to configure it once in midgard live with it configured that way for all other projects that use it. bah~~

i havent tested it yet but i thought about it a lot last night and because the macros are in the header that means that each time they get included in a compilation unit the preprocessor directives for that compilation will be evaluated. that means you should be able to compile it multiple times and change the logging level in the given library. in fact i think we've proven this works using the logging test already. note that the test passes -DLOGGING_LEVEL_ALL and still logs all levels even if you've configured with LOGGING_LEVEL_INFO for example.