### PR TITLE
set defines

### DIFF
--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -49,28 +49,34 @@ void Configure(const LoggingConfig& config);
 
 //convenience macros stand out when reading code
 //default to seeing INFO and up if nothing was specified
-#ifndef LOGGING_LEVEL_ERROR
-  #ifndef LOGGING_LEVEL_WARN
-    #ifndef LOGGING_LEVEL_INFO
-      #ifndef LOGGING_LEVEL_DEBUG
-        #ifndef LOGGING_LEVEL_TRACE
-          #define LOGGING_LEVEL_INFO
+#ifndef LOGGING_LEVEL_NONE
+  #ifndef LOGGING_LEVEL_ALL
+    #ifndef LOGGING_LEVEL_ERROR
+      #ifndef LOGGING_LEVEL_WARN
+        #ifndef LOGGING_LEVEL_INFO
+          #ifndef LOGGING_LEVEL_DEBUG
+            #ifndef LOGGING_LEVEL_TRACE
+              #define LOGGING_LEVEL_INFO
+            #endif
+          #endif
         #endif
       #endif
     #endif
   #endif
 #endif
 //mark all the stuff we should see
-#ifndef LOGGING_LEVEL_ERROR
-  #define LOGGING_LEVEL_ERROR
-  #ifndef LOGGING_LEVEL_WARN
-    #define LOGGING_LEVEL_WARN
-    #ifndef LOGGING_LEVEL_INFO
-      #define LOGGING_LEVEL_INFO
-      #ifndef LOGGING_LEVEL_DEBUG
-        #define LOGGING_LEVEL_DEBUG
-        #ifndef LOGGING_LEVEL_TRACE
-          #define LOGGING_LEVEL_TRACE
+#ifndef LOGGING_LEVEL_NONE
+  #ifndef LOGGING_LEVEL_ERROR
+    #define LOGGING_LEVEL_ERROR
+    #ifndef LOGGING_LEVEL_WARN
+      #define LOGGING_LEVEL_WARN
+      #ifndef LOGGING_LEVEL_INFO
+        #define LOGGING_LEVEL_INFO
+        #ifndef LOGGING_LEVEL_DEBUG
+          #define LOGGING_LEVEL_DEBUG
+          #ifndef LOGGING_LEVEL_TRACE
+            #define LOGGING_LEVEL_TRACE
+          #endif
         #endif
       #endif
     #endif


### PR DESCRIPTION
sometimes when you want to log something it requires a little bit computation to determine what to log, ifs some arithmetic, whatever. it would be nice if before we even compile any of that stuff we could know if it were going to be logged anyway based on the level that is globally defined. this pr enables that. heres a concrete example from oden:

https://github.com/valhalla/odin/pull/11