### PR TITLE
add custom log level and test for it

### DIFF
--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -93,7 +93,7 @@ class StdOutLogger : public Logger {
   virtual void Log(const std::string& message, const LogLevel level) {
     Log(message, levels.find(level)->second);
   }
-  virtual void Log(const std::string& message, const std::string& custom_directive = "TRACE") {
+  virtual void Log(const std::string& message, const std::string& custom_directive = " [TRACE] ") {
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());
@@ -144,7 +144,7 @@ class FileLogger : public Logger {
   virtual void Log(const std::string& message, const LogLevel level) {
     Log(message, uncolored.find(level)->second);
   }
-  virtual void Log(const std::string& message,  const std::string& custom_directive = "TRACE") {
+  virtual void Log(const std::string& message,  const std::string& custom_directive = " [TRACE] ") {
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());

--- a/src/midgard/logging.cc
+++ b/src/midgard/logging.cc
@@ -81,6 +81,7 @@ const std::unordered_map<LogLevel, std::string, EnumHasher> colored
 Logger::Logger(const LoggingConfig& config) {};
 Logger::~Logger() {};
 void Logger::Log(const std::string&, const LogLevel) {};
+void Logger::Log(const std::string&, const std::string&) {};
 bool logger_registered =
   RegisterLogger("", [](const LoggingConfig& config){Logger* l = new Logger(config); return l;});
 
@@ -90,10 +91,13 @@ class StdOutLogger : public Logger {
   StdOutLogger() = delete;
   StdOutLogger(const LoggingConfig& config) : Logger(config), levels(config.find("color") != config.end() && config.find("color")->second == "true" ? colored : uncolored) {}
   virtual void Log(const std::string& message, const LogLevel level) {
+    Log(message, levels.find(level)->second);
+  }
+  virtual void Log(const std::string& message, const std::string& custom_directive = "TRACE") {
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());
-    output.append(levels.find(level)->second);
+    output.append(custom_directive);
     output.append(message);
     output.push_back('\n');
     //cout is thread safe, to avoid multiple threads interleaving on one line
@@ -138,10 +142,13 @@ class FileLogger : public Logger {
     ReOpen();
   }
   virtual void Log(const std::string& message, const LogLevel level) {
+    Log(message, uncolored.find(level)->second);
+  }
+  virtual void Log(const std::string& message,  const std::string& custom_directive = "TRACE") {
     std::string output;
     output.reserve(message.length() + 64);
     output.append(TimeStamp());
-    output.append(uncolored.find(level)->second);
+    output.append(custom_directive);
     output.append(message);
     output.push_back('\n');
     lock.lock();
@@ -184,6 +191,16 @@ bool file_logger_registered =
 logging::Logger& logging::GetLogger(const LoggingConfig& config) {
   static std::unique_ptr<Logger> singleton(GetFactory().Produce(config));
   return *singleton;
+}
+
+//statically log manually
+void logging::Log(const std::string& message, const logging::LogLevel level) {
+  GetLogger().Log(message, level);
+}
+
+//statically log manually
+void logging::Log(const std::string& message, const std::string& custom_directive) {
+  GetLogger().Log(message, custom_directive);
 }
 
 //statically configure logging

--- a/test/logging.cc
+++ b/test/logging.cc
@@ -25,7 +25,7 @@ size_t work() {
     LOG_INFO(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
     LOG_DEBUG(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
     LOG_TRACE(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    valhalla::midgard::logging::Log("s.str()", "CUSTOM");
+    valhalla::midgard::logging::Log(s.str(), " [CUSTOM] ");
   }
   return 10;
 }
@@ -69,12 +69,12 @@ void ThreadFileLoggerTest() {
   std::string line;
   size_t error = 0, warn = 0, info = 0, debug = 0, trace = 0, custom = 0;
   while(std::getline(file, line)){
-    error += (line.find("ERROR") != std::string::npos);
-    warn += (line.find("WARN") != std::string::npos);
-    info += (line.find("INFO") != std::string::npos);
-    debug += (line.find("DEBUG") != std::string::npos);
-    trace += (line.find("TRACE") != std::string::npos);
-    custom += (line.find("CUSTOM") != std::string::npos);
+    error += (line.find(" [ERROR] ") != std::string::npos);
+    warn += (line.find(" [WARN] ") != std::string::npos);
+    info += (line.find(" [INFO] ") != std::string::npos);
+    debug += (line.find(" [DEBUG] ") != std::string::npos);
+    trace += (line.find(" [TRACE] ") != std::string::npos);
+    custom += (line.find(" [CUSTOM] ") != std::string::npos);
     line.clear();
   }
   size_t line_count = error + warn + info + debug + trace;

--- a/test/logging.cc
+++ b/test/logging.cc
@@ -25,6 +25,7 @@ size_t work() {
     LOG_INFO(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
     LOG_DEBUG(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
     LOG_TRACE(s.str()); std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    valhalla::midgard::logging::Log("s.str()", "CUSTOM");
   }
   return 10;
 }
@@ -59,26 +60,27 @@ void ThreadFileLoggerTest() {
   }
 
   //wait for logger to close and reopen the file
-  std::this_thread::sleep_for(std::chrono::milliseconds(1010));
   LOG_TRACE("force log close/reopen");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1010));
 
   //open up the file and make sure it looks right
   std::ifstream file("test/thread_file_log_test.log");
 
   std::string line;
-  size_t error = 0, warn = 0, info = 0, debug = 0, trace = 0;
+  size_t error = 0, warn = 0, info = 0, debug = 0, trace = 0, custom = 0;
   while(std::getline(file, line)){
     error += (line.find("ERROR") != std::string::npos);
     warn += (line.find("WARN") != std::string::npos);
     info += (line.find("INFO") != std::string::npos);
     debug += (line.find("DEBUG") != std::string::npos);
     trace += (line.find("TRACE") != std::string::npos);
+    custom += (line.find("CUSTOM") != std::string::npos);
     line.clear();
   }
   size_t line_count = error + warn + info + debug + trace;
   if(line_count != 41)
     throw std::runtime_error("Log should have exactly 40 lines but had " + std::to_string(line_count));
-  if(error != 8 || warn != 8 || info != 8 || debug != 8 || trace != 9)
+  if(error != 8 || warn != 8 || info != 8 || debug != 8 || trace != 9 || custom != 8)
     throw std::runtime_error("Wrong distribution of log messages");
 }
 

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -34,12 +34,17 @@ class Logger {
   Logger(const LoggingConfig& config);
   virtual ~Logger();
   virtual void Log(const std::string&, const LogLevel);
+  virtual void Log(const std::string&, const std::string& custom_directive = "TRACE");
  protected:
   std::mutex lock;
 };
 
 //statically get a logger using the factory
 Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color", "true"} });
+
+//statically log manually without the macros below
+void Log(const std::string&, const LogLevel);
+void Log(const std::string&, const std::string& custom_directive = "TRACE");
 
 //statically configure logging
 //try something like:

--- a/valhalla/midgard/logging.h
+++ b/valhalla/midgard/logging.h
@@ -34,7 +34,7 @@ class Logger {
   Logger(const LoggingConfig& config);
   virtual ~Logger();
   virtual void Log(const std::string&, const LogLevel);
-  virtual void Log(const std::string&, const std::string& custom_directive = "TRACE");
+  virtual void Log(const std::string&, const std::string& custom_directive = " [TRACE] ");
  protected:
   std::mutex lock;
 };
@@ -44,7 +44,7 @@ Logger& GetLogger(const LoggingConfig& config = { {"type", "std_out"}, {"color",
 
 //statically log manually without the macros below
 void Log(const std::string&, const LogLevel);
-void Log(const std::string&, const std::string& custom_directive = "TRACE");
+void Log(const std::string&, const std::string& custom_directive = " [TRACE] ");
 
 //statically configure logging
 //try something like:


### PR DESCRIPTION
this less you log with a custom log level:

    2015/02/02 16:18:09.516777 [CUSTOM] hi my name is: 47610380150528
    2015/02/02 16:18:09.516798 [ERROR] hi my name is: 47610380150528
    2015/02/02 16:18:09.516783 [ERROR] hi my name is: 47610382251776
    2015/02/02 16:18:09.516783 [ERROR] hi my name is: 47610519881472
    2015/02/02 16:18:09.516725 [CUSTOM] hi my name is: 47610378049280
    2015/02/02 16:18:09.516873 [ERROR] hi my name is: 47610378049280
    2015/02/02 16:18:09.526927 [WARN] hi my name is: 47610519881472


note this shows an example of how to use logging without the macros. it is highely discouraged to use logging without the macros as it circumvents the mechanism by which we set the verbosity of a build. in other words please dont use logging without using the macros unless you really really must log with a custom log level.