### PR TITLE
Update AABB2 intersection with a segment to use half-space 

### DIFF
--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -153,6 +153,14 @@ int32_t Tiles::BottomNeighbor(const int32_t tileid) const {
   return (tileid < ncolumns_) ? tileid : tileid - ncolumns_;
 }
 
+// Checks if 2 tiles are neighbors (N,E,S,W).
+bool Tiles::AreNeighbors(const uint32_t id1, const uint32_t id2) const {
+  return (id2 == TopNeighbor(id1) ||
+          id2 == RightNeighbor(id1) ||
+          id2 == BottomNeighbor(id1) ||
+          id2 == LeftNeighbor(id1));
+}
+
 const std::vector<int>& Tiles::TileList(const AABB2& boundingbox) {
   // Clear lists
   checklist_.clear();

--- a/test/aabb2.cc
+++ b/test/aabb2.cc
@@ -32,14 +32,37 @@ void TestContainsBb() {
                 AABB2(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryIntesectsLn(const AABB2& a, const AABB2& b) {
-  if (!a.Intersect(a.Center(), b.Center()))
+void TryIntesectsLn(const AABB2& box, const Point2& a,
+                    const Point2& b, bool expected) {
+  if (box.Intersect(a, b) != expected)
     throw runtime_error("Intersects line test failed");
 }
 
 void TestIntersectsLn() {
-  TryIntesectsLn(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
-                 AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  AABB2 box(40.0f, -76.0f, 41.0f, -75.0f);
+
+  // Test with one or both points in the box
+  TryIntesectsLn(box, Point2(40.5f, -75.5f), Point2(41.5f, -75.5f), true);
+  TryIntesectsLn(box, Point2(38.0f, -80.0f), Point2(40.5f, -75.5f), true);
+  TryIntesectsLn(box, Point2(40.5f, -75.5f), Point2(40.8f, -75.8f), true);
+
+  // Quick rejection tests
+  TryIntesectsLn(box, Point2(42.5f, -76.5f), Point2(41.5f, -75.5f), false);
+  TryIntesectsLn(box, Point2(42.5f, -80.5f), Point2(41.5f, -85.5f), false);
+  TryIntesectsLn(box, Point2(42.5f, -70.5f), Point2(41.5f, -75.5f), false);
+  TryIntesectsLn(box, Point2(26.5f, -80.5f), Point2(39.5f, -85.5f), false);
+
+  // Endpoint on the boundary
+  TryIntesectsLn(box, Point2(40.0f, -75.5f), Point2(36.5f, -74.0f), true);
+  TryIntesectsLn(box, Point2(40.0f, -75.0f), Point2(36.5f, -74.0f), true);
+
+  // Through the box (horizontal, vertical, other)
+  TryIntesectsLn(box, Point2(40.5f, -77.0f), Point2(40.5f, -74.0f), true);
+  TryIntesectsLn(box, Point2(39.5f, -75.5f), Point2(41.5f, -75.5f), true);
+  TryIntesectsLn(box, Point2(39.5f, -75.9f), Point2(40.5f, -74.8f), true);
+
+  // Outside the corner
+  TryIntesectsLn(box, Point2(39.2f, -75.5f), Point2(40.5f, -74.5f), false);
 }
 
 void TryContainsPt(const AABB2& a, const AABB2& b) {

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -201,6 +201,14 @@ class Tiles {
   int32_t BottomNeighbor(const int32_t tileid) const;
 
   /**
+   * Checks if 2 tiles are neighbors (N,E,S,W).
+   * @param  id1  Tile Id 1
+   * @param  id2  Tile Id 2
+   * @return  Returns true if tile id1 and id2 are neighbors, false if not.
+   */
+  bool AreNeighbors(const uint32_t id1, const uint32_t id2) const;
+
+  /**
    * Gets the list of tiles that lie within the specified bounding box.
    * The method finds the center tile and spirals out by finding neighbors
    * and recursively checking if tile is inside and checking/adding


### PR DESCRIPTION
(any one corner must lie on an opposing side of the line than the others).  Update test to have many different cases for segment intersecting a bounding box.
Add a AreNeighbors convenience method to Tiles. 