### PR TITLE
some os's dont have /proc. this fixes #49

### DIFF
--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <fstream>
 #include <algorithm>
+#include <sys/stat.h>
 
 namespace {
 constexpr double POLYLINE_PRECISION = 1E6;
@@ -174,6 +175,11 @@ memory_status::memory_status(const std::unordered_set<std::string> interest){
     }
     line.clear();
   }
+}
+
+bool memory_status::supported() {
+  struct stat s;
+  return stat("/proc/self/status", &s) == 0;
 }
 
 std::ostream& operator<<(std::ostream& stream, const memory_status& s){

--- a/test/util.cc
+++ b/test/util.cc
@@ -65,17 +65,20 @@ void AppxEqual() {
 }
 
 void MemoryStatus() {
-  memory_status status({"VmSize", "VmSwap", "VmPeak"});
+  //only check this if the os supports it (system must have /proc/self/status)
+  if(memory_status::supported()){
+    memory_status status({"VmSize", "VmSwap", "VmPeak"});
 
-  //should have each of these
-  for(const auto& key : {"VmSize", "VmSwap", "VmPeak"}) {
-    auto value = status.metrics.find(key);
-    if(value == status.metrics.end())
-      throw std::runtime_error("Missing memory statistic for " + std::string(key));
-    if(value->second.first < 0.)
-      throw std::runtime_error("Negative memory usage values are not allowed");
-    if(value->second.second.back() != 'B')
-      throw std::runtime_error("Units should be some magnitude of bytes");
+    //should have each of these
+    for(const auto& key : {"VmSize", "VmSwap", "VmPeak"}) {
+      auto value = status.metrics.find(key);
+      if(value == status.metrics.end())
+        throw std::runtime_error("Missing memory statistic for " + std::string(key));
+      if(value->second.first < 0.)
+        throw std::runtime_error("Negative memory usage values are not allowed");
+      if(value->second.second.back() != 'B')
+        throw std::runtime_error("Units should be some magnitude of bytes");
+    }
   }
 }
 

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -133,6 +133,8 @@ struct memory_status {
 
   std::unordered_map<std::string, std::pair<double, std::string> > metrics;
 
+  static bool supported();
+
   friend std::ostream& operator<<(std::ostream&, const memory_status&);
 };
 std::ostream& operator<<(std::ostream& stream, const memory_status& s);


### PR DESCRIPTION
openbsd doesnt have procfs. you can apparently install it but by default it is now removed. easiest way to make this pass without really worrying about how to get this info from os's that donst support it is to disable it for those os's. we dont make use of it for anything mission critical so (more for instrumentation) so its fine to disable if its not supported.