### PR TITLE
Make this a template class

### DIFF
--- a/src/midgard/obb2.cc
+++ b/src/midgard/obb2.cc
@@ -4,7 +4,8 @@ namespace valhalla {
 namespace midgard {
 
 // Default constructor
-OBB2::OBB2()
+template <class coord_t>
+OBB2<coord_t>::OBB2()
     : extent0_(0),
       extent1_(0) {
 }
@@ -12,16 +13,18 @@ OBB2::OBB2()
 // Construct an oriented bounding box given 4 corners. The center is found by
 // the average of the 4 vertex positions and the axes of the OBB are formed
 // by a vector from a0 to a1 and the other by a vector from a1 to a2.
-OBB2::OBB2(const Point2& a0, const Point2& a1,
-           const Point2& a2, const Point2& a3) {
+template <class coord_t>
+OBB2<coord_t>::OBB2(const coord_t& a0, const coord_t& a1,
+                    const coord_t& a2, const coord_t& a3) {
   Set(a0, a1, a2, a3);
 }
 
 // Set an oriented bounding box given 4 corners. The center is found by
 // the average of the 4 vertex positions and the axes of the OBB are formed
 // by a vector from a0 to a1 and the other by a vector from a1 to a2.
-void OBB2::Set(const Point2& a0, const Point2& a1,
-               const Point2& a2, const Point2& a3) {
+template <class coord_t>
+void OBB2<coord_t>::Set(const coord_t& a0, const coord_t& a1,
+                        const coord_t& a2, const coord_t& a3) {
   // Find center positions of each bounding box
   center_.Set((a0.x() + a1.x() + a2.x() + a3.x()) * 0.25f,
               (a0.y() + a1.y() + a2.y() + a3.y()) * 0.25f);
@@ -40,7 +43,8 @@ void OBB2::Set(const Point2& a0, const Point2& a1,
 
 // Check if two oriented bounding boxes overlap. Uses the separating
 // axis theorem.
-bool OBB2::Overlap(const OBB2& b) const {
+template <class coord_t>
+bool OBB2<coord_t>::Overlap(const OBB2<coord_t>& b) const {
   // Translation of B into A's frame
   Vector2 v(center_, b.center_);
   Vector2 t(v.Dot(basis0_), v.Dot(basis1_));
@@ -73,6 +77,10 @@ bool OBB2::Overlap(const OBB2& b) const {
   // No separating axis found, the two boxes overlap
   return true;
 }
+
+// Explicit instantiation
+template class OBB2<Point2>;
+template class OBB2<PointLL>;
 
 }
 }

--- a/test/obb2.cc
+++ b/test/obb2.cc
@@ -4,29 +4,49 @@
 
 #include <vector>
 
-#include "valhalla/midgard/point2.h"
-#include "valhalla/midgard/vector2.h"
+//#include "valhalla/midgard/point2.h"
+//#include "valhalla/midgard/pointll.h"
+//#include "valhalla/midgard/vector2.h"
 
 using namespace std;
 using namespace valhalla::midgard;
 
 namespace {
 
-void TryOverlap(const OBB2& a, const OBB2& b, const bool expected) {
+// Test if 2 oriented bounding boxes overlap
+void TryOverlap(const OBB2<Point2>& a, const OBB2<Point2>& b,
+                const bool expected) {
   if (a.Overlap(b) != expected) {
-    throw runtime_error("OBB Overlap test failed: expected: " +
+    throw runtime_error("OBB<Point2> Overlap test failed: expected: " +
+                        std::to_string(expected));
+  }
+}
+
+// Test if 2 lat,lng oriented bounding boxes overlap
+void TryOverlapLL(const OBB2<PointLL>& a, const OBB2<PointLL>& b,
+                  const bool expected) {
+  if (a.Overlap(b) != expected) {
+    throw runtime_error("OBB<PointLL> Overlap test failed: expected: " +
                         std::to_string(expected));
   }
 }
 
 void TestOverlap() {
-  OBB2 a({1,1}, {2,-1}, {6,1}, {5,3});
-  OBB2 b({-1,3}, {-2,2}, {-1,1}, {0,2});
-  OBB2 c({1,4}, {0,3}, {4,-1}, {5,0});
-
+  // Test cases in x,y
+  OBB2<Point2> a({1,1}, {2,-1}, {6,1}, {5,3});
+  OBB2<Point2> b({-1,3}, {-2,2}, {-1,1}, {0,2});
+  OBB2<Point2> c({1,4}, {0,3}, {4,-1}, {5,0});
   TryOverlap(a, b, false);
   TryOverlap(a, c, true);
   TryOverlap(b, c, false);
+
+  // Same test cases with lat,lng
+  OBB2<PointLL> d({1,1}, {2,-1}, {6,1}, {5,3});
+  OBB2<PointLL> e({-1,3}, {-2,2}, {-1,1}, {0,2});
+  OBB2<PointLL> f({1,4}, {0,3}, {4,-1}, {5,0});
+  TryOverlapLL(d, e, false);
+  TryOverlapLL(d, f, true);
+  TryOverlapLL(e, f, false);
 }
 
 }

--- a/test/obb2.cc
+++ b/test/obb2.cc
@@ -4,10 +4,6 @@
 
 #include <vector>
 
-//#include "valhalla/midgard/point2.h"
-//#include "valhalla/midgard/pointll.h"
-//#include "valhalla/midgard/vector2.h"
-
 using namespace std;
 using namespace valhalla::midgard;
 

--- a/valhalla/midgard/obb2.h
+++ b/valhalla/midgard/obb2.h
@@ -5,6 +5,7 @@
 #include <math.h>
 
 #include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/vector2.h>
 
 namespace valhalla {
@@ -13,8 +14,10 @@ namespace midgard {
 /**
  * Oriented bounding box (2-D). Simple collision detection method
  * where an OBB is set by its 4 corners and an overlap/collision check
- * can be performed against another OBB.
+ * can be performed against another OBB. Template class to work with
+ * Point2 (Euclidean x,y) or PointLL (latitude,longitude).
  */
+template <class coord_t>
 class OBB2 {
  public:
   /**
@@ -31,8 +34,8 @@ class OBB2 {
    * @param  a2  Corner vertex on the bounding box.
    * @param  a3  Corner vertex on the bounding box.
    */
-  OBB2(const Point2& a0, const Point2& a1,
-       const Point2& a2, const Point2& a3);
+  OBB2(const coord_t& a0, const coord_t& a1,
+       const coord_t& a2, const coord_t& a3);
 
   /**
    * Set an oriented bounding box given 4 corners. The center is found by
@@ -43,8 +46,8 @@ class OBB2 {
    * @param  a2  Corner vertex on the bounding box.
    * @param  a3  Corner vertex on the bounding box.
    */
-  void Set(const Point2& a0, const Point2& a1,
-           const Point2& a2, const Point2& a3);
+  void Set(const coord_t& a0, const coord_t& a1,
+           const coord_t& a2, const coord_t& a3);
 
   /**
    * Check if two oriented bounding boxes overlap. Uses the separating
@@ -55,7 +58,7 @@ class OBB2 {
   bool Overlap(const OBB2& b) const;
 
  private:
-   Point2  center_;   // Center of the oriented bounding box
+   coord_t center_;   // Center of the oriented bounding box
    float   extent0_;  // Half length along the basis vector 0
    float   extent1_;  // Half length along the basis vector 1
    Vector2 basis0_;   // Basis vector defined by 1st edge


### PR DESCRIPTION
Accepting Point2 or PointLL. Update tests to include a PointLL test.

This is the first of several midgard updates to use templates for coordinate type (Point2 or PointLL). Doing this one first since it is not yet used anywhere.