### PR TITLE
Template class so geometric objects accept a coordinate type

### DIFF
--- a/src/midgard/aabb2.cc
+++ b/src/midgard/aabb2.cc
@@ -5,7 +5,8 @@ namespace valhalla {
 namespace midgard {
 
 // Default constructor
-AABB2::AABB2()
+template <class coord_t>
+AABB2<coord_t>::AABB2()
     : minx_(0.0f),
       miny_(0.0f),
       maxx_(0.0f),
@@ -13,7 +14,8 @@ AABB2::AABB2()
 }
 
 // Construct an AABB given a minimum and maximum point.
-AABB2::AABB2(const Point2& minpt, const Point2& maxpt) {
+template <class coord_t>
+AABB2<coord_t>::AABB2(const coord_t& minpt, const coord_t& maxpt) {
   minx_ = minpt.x();
   miny_ = minpt.y();
   maxx_ = maxpt.x();
@@ -21,8 +23,9 @@ AABB2::AABB2(const Point2& minpt, const Point2& maxpt) {
 }
 
 // Constructor with specified bounds.
-AABB2::AABB2(const float minx, const float miny, const float maxx,
-             const float maxy) {
+template <class coord_t>
+AABB2<coord_t>::AABB2(const float minx, const float miny,
+                      const float maxx, const float maxy) {
   minx_ = minx;
   miny_ = miny;
   maxx_ = maxx;
@@ -30,48 +33,57 @@ AABB2::AABB2(const float minx, const float miny, const float maxx,
 }
 
 // Construct an AABB given a list of points.
-AABB2::AABB2(std::vector<Point2>& pts) {
+template <class coord_t>
+AABB2<coord_t>::AABB2(const std::vector<coord_t>& pts) {
   Create(pts);
 }
 
 // Equality operator.
-bool AABB2::operator ==(const AABB2& r2) const {
+template <class coord_t>
+bool AABB2<coord_t>::operator ==(const AABB2<coord_t>& r2) const {
   return (minx_ == r2.minx() && maxx_ == r2.maxx() &&
           miny_ == r2.miny() && maxy_ == r2.maxy());
 }
 
 // Get the minimum x.
-float AABB2::minx() const {
+template <class coord_t>
+float AABB2<coord_t>::minx() const {
   return minx_;
 }
 
 // Get the maximum x.
-float AABB2::maxx() const {
+template <class coord_t>
+float AABB2<coord_t>::maxx() const {
   return maxx_;
 }
 
 // Get the minimum y.
-float AABB2::miny() const {
+template <class coord_t>
+float AABB2<coord_t>::miny() const {
   return miny_;
 }
 
 // Get the maximum y.
-float AABB2::maxy() const {
+template <class coord_t>
+float AABB2<coord_t>::maxy() const {
   return maxy_;
 }
 
 // Get the point at the minimum x,y.
-Point2 AABB2::minpt() const {
-  return Point2(minx_, miny_);
+template <class coord_t>
+coord_t AABB2<coord_t>::minpt() const {
+  return coord_t(minx_, miny_);
 }
 
 // Get the point at the maximum x,y.
-Point2 AABB2::maxpt() const {
-  return Point2(maxx_, maxy_);
+template <class coord_t>
+coord_t AABB2<coord_t>::maxpt() const {
+  return coord_t(maxx_, maxy_);
 }
 
 // Creates an AABB given a list of points.
-void AABB2::Create(const std::vector<Point2>& pts) {
+template <class coord_t>
+void AABB2<coord_t>::Create(const std::vector<coord_t>& pts) {
   auto p = pts.begin();
   minx_ = p->x();
   maxx_ = minx_;
@@ -93,24 +105,28 @@ void AABB2::Create(const std::vector<Point2>& pts) {
 }
 
 // Gets the center of the bounding box.
-Point2 AABB2::Center() const {
-  return Point2((minx_ + maxx_) * 0.5f, (miny_ + maxy_) * 0.5f);
+template <class coord_t>
+coord_t AABB2<coord_t>::Center() const {
+  return coord_t((minx_ + maxx_) * 0.5f, (miny_ + maxy_) * 0.5f);
 }
 
 // Tests if a specified point is within the bounding box.
-bool AABB2::Contains(const Point2& pt) const {
+template <class coord_t>
+bool AABB2<coord_t>::Contains(const coord_t& pt) const {
   return (pt.x() >= minx_ && pt.y() >= miny_ &&
           pt.x() <  maxx_ && pt.y() <  maxy_);
 }
 
 // Checks to determine if another bounding box is completely inside
 // this bounding box.
-bool AABB2::Contains(const AABB2& r2) const {
+template <class coord_t>
+bool AABB2<coord_t>::Contains(const AABB2<coord_t>& r2) const {
   return (Contains(r2.minpt()) && Contains(r2.maxpt()));
 }
 
 // Test if this bounding box intersects another bounding box.
-bool AABB2::Intersects(const AABB2& r2) const {
+template <class coord_t>
+bool AABB2<coord_t>::Intersects(const AABB2<coord_t>& r2) const {
   // The bounding boxes do NOT intersect if the other bounding box (r2) is
   // entirely LEFT, BELOW, RIGHT, or ABOVE this bounding box.
   if ((r2.minx() < minx_ && r2.maxx() < minx_) ||
@@ -123,12 +139,14 @@ bool AABB2::Intersects(const AABB2& r2) const {
 }
 
 // Tests whether the segment intersects the bounding box.
-bool AABB2::Intersect(const LineSegment2& seg) const {
+template <class coord_t>
+bool AABB2<coord_t>::Intersect(const LineSegment2<coord_t>& seg) const {
   return Intersect(seg.a(), seg.b());
 }
 
 // Tests whether the segment intersects the bounding box.
-bool AABB2::Intersect(const Point2& a, const Point2& b) const {
+template <class coord_t>
+bool AABB2<coord_t>::Intersect(const coord_t& a, const coord_t& b) const {
   // Trivial case - either point within the bounding box
   if (Contains(a) || Contains(b))
     return true;
@@ -146,31 +164,29 @@ bool AABB2::Intersect(const Point2& a, const Point2& b) const {
   // segment. Any corner point on the segment half plane will have
   // IsLeft == 0 and we count as an intersection (trivial rejection cases
   // above mean the segment reaches the corner point)
-  LineSegment2 s(a, b);
-  float s1 = s.IsLeft(Point2(minx_, miny_));
-  return ((s1 * s.IsLeft(Point2(minx_, maxy_)) <= 0.0f) ||
-          (s1 * s.IsLeft(Point2(maxx_, maxy_)) <= 0.0f) ||
-          (s1 * s.IsLeft(Point2(maxx_, miny_)) <= 0.0f));
+  LineSegment2<coord_t> s(a, b);
+  float s1 = s.IsLeft(coord_t(minx_, miny_));
+  return ((s1 * s.IsLeft(coord_t(minx_, maxy_)) <= 0.0f) ||
+          (s1 * s.IsLeft(coord_t(maxx_, maxy_)) <= 0.0f) ||
+          (s1 * s.IsLeft(coord_t(maxx_, miny_)) <= 0.0f));
 }
 
 // Gets the width of the bounding box.
-float AABB2::Width() const {
+template <class coord_t>
+float AABB2<coord_t>::Width() const {
   return maxx_ - minx_;
 }
 
 // Gets the height of the bounding box.
-float AABB2::Height() const {
+template <class coord_t>
+float AABB2<coord_t>::Height() const {
   return maxy_ - miny_;
-}
-
-// Gets the area of the bounding box.
-float AABB2::Area() const {
-  return Width() * Height();
 }
 
 // Expands (if necessary) the bounding box to include the specified
 // bounding box.
-void AABB2::Expand(const AABB2& r2) {
+template <class coord_t>
+void AABB2<coord_t>::Expand(const AABB2<coord_t>& r2) {
   if (r2.minx() < minx_)
     minx_ = r2.minx();
   if (r2.miny() < miny_)
@@ -180,6 +196,10 @@ void AABB2::Expand(const AABB2& r2) {
   if (r2.maxy() > maxy_)
     maxy_ = r2.maxy();
 }
+
+// Explicit instantiation
+template class AABB2<Point2>;
+template class AABB2<PointLL>;
 
 }
 }

--- a/src/midgard/clipper2.cc
+++ b/src/midgard/clipper2.cc
@@ -5,8 +5,10 @@ namespace midgard {
 
 // Clips the input set of vertices to the specified boundary.  Uses a
 // method where the shape is clipped against each edge in succession.
-uint32_t Clipper2::Clip(const AABB2& bbox, std::vector<Point2>& pts,
-                        const bool closed) {
+template <class coord_t>
+uint32_t Clipper2<coord_t>::Clip(const AABB2<coord_t>& bbox,
+                                 std::vector<coord_t>& pts,
+                                 const bool closed) {
   // Save the boundary
   minx_ = bbox.minx();
   maxx_ = bbox.maxx();
@@ -14,7 +16,7 @@ uint32_t Clipper2::Clip(const AABB2& bbox, std::vector<Point2>& pts,
   maxy_ = bbox.maxy();
 
   // Temporary vertex list
-  std::vector<Point2> tmp_pts;
+  std::vector<coord_t> tmp_pts;
 
   // Clip against each edge in succession. At each step we swap the roles
   // of the 2 vertex lists. If at any time there are no points remaining we
@@ -37,9 +39,11 @@ uint32_t Clipper2::Clip(const AABB2& bbox, std::vector<Point2>& pts,
 }
 
 // Clips the polyline/polygon against a single edge.
-uint32_t Clipper2::ClipAgainstEdge(const ClipEdge bdry, const bool closed,
-                              const std::vector<Point2>& vin,
-                              std::vector<Point2>& vout) {
+template <class coord_t>
+uint32_t Clipper2<coord_t>::ClipAgainstEdge(const ClipEdge bdry,
+                              const bool closed,
+                              const std::vector<coord_t>& vin,
+                              std::vector<coord_t>& vout) {
   // Clear the output vector
   vout.clear();
 
@@ -75,9 +79,11 @@ uint32_t Clipper2::ClipAgainstEdge(const ClipEdge bdry, const bool closed,
 // Finds the intersection of the segment from insidept to outsidept with the
 // specified boundary edge.  Finds the intersection using the parametric
 // line equation.
-Point2 Clipper2::ClipIntersection(const ClipEdge bdry, const Point2& insidept,
-                                  const Point2& outsidept) {
-  float t = 0.0;
+template <class coord_t>
+coord_t Clipper2<coord_t>::ClipIntersection(const ClipEdge bdry,
+                                            const coord_t& insidept,
+                                            const coord_t& outsidept) {
+  float t = 0.0f;
   float inx = insidept.x();
   float iny = insidept.y();
   float dx = outsidept.x() - inx;
@@ -98,12 +104,13 @@ Point2 Clipper2::ClipIntersection(const ClipEdge bdry, const Point2& insidept,
   }
 
   // Return the intersection point.
-  return Point2(inx + t * dx, iny + t * dy);
+  return coord_t(inx + t * dx, iny + t * dy);
 }
 
 // Tests if the vertex is inside the rectangular boundary with respect to
 // the specified edge.
-bool Clipper2::Inside(const ClipEdge edge, const Point2& v) const {
+template <class coord_t>
+bool Clipper2<coord_t>::Inside(const ClipEdge edge, const coord_t& v) const {
   switch (edge) {
     case kLeft:
       return (v.x() > minx_);
@@ -118,11 +125,16 @@ bool Clipper2::Inside(const ClipEdge edge, const Point2& v) const {
 }
 
 // Add vertex to clip output (if not same as prior vertex)
-void Clipper2::Add(const Point2& pt, std::vector<Point2>& vout) {
+template <class coord_t>
+void Clipper2<coord_t>::Add(const coord_t& pt, std::vector<coord_t>& vout) {
   if (vout.size() == 0 || vout.back() != pt) {
     vout.push_back(pt);
   }
 }
+
+// Explicit instantiation
+template class Clipper2<Point2>;
+template class Clipper2<PointLL>;
 
 }
 }

--- a/src/midgard/ellipse.cc
+++ b/src/midgard/ellipse.cc
@@ -4,7 +4,8 @@ namespace valhalla {
 namespace midgard {
 
 // Default constructor.
-Ellipse::Ellipse()
+template <class coord_t>
+Ellipse<coord_t>::Ellipse()
     : s(0),
       c(0) {
   center_.Set(0.0f, 0.0f);
@@ -13,7 +14,8 @@ Ellipse::Ellipse()
 }
 
 // Constructor given bounding rectangle and a rotation.
-Ellipse::Ellipse(const Point2& p1, const Point2& p2, float angle) {
+template <class coord_t>
+Ellipse<coord_t>::Ellipse(const coord_t& p1, const coord_t& p2, float angle) {
   // Set the center and get sin and cos of the angle
   center_.Set(p1.x() + p2.x() * 0.5f, p1.y() + p2.y() * 0.5f);
   float angleRad = angle * kRadPerDeg;
@@ -40,8 +42,9 @@ Ellipse::Ellipse(const Point2& p1, const Point2& p2, float angle) {
 
 // Determines if a line segment intersects the ellipse and if so
 // finds the point(s) of intersection.
-uint32_t Ellipse::Intersect(const LineSegment2& seg, Point2& pt0,
-                            Point2& pt1) const {
+template <class coord_t>
+uint32_t Ellipse<coord_t>::Intersect(const LineSegment2<coord_t>& seg,
+                                     coord_t& pt0,  coord_t& pt1) const {
   // Solution is found by parameterizing the line segment and
   // substituting those values into the ellipse equation resulting
   // in a quadratic equation.
@@ -109,30 +112,31 @@ uint32_t Ellipse::Intersect(const LineSegment2& seg, Point2& pt0,
 
 // Does the specified axis-aligned bounding box (rectangle) intersect
 // this ellipse.
-IntersectCase Ellipse::DoesIntersect(const AABB2& r) const {
+template <class coord_t>
+IntersectCase Ellipse<coord_t>::DoesIntersect(const AABB2<coord_t>& r) const {
   // Test if all 4 corners of the rectangle are inside the ellipse
-  Point2 ul(r.minx(), r.maxy());
-  Point2 ur(r.maxx(), r.maxy());
-  Point2 ll(r.minx(), r.miny());
-  Point2 lr(r.maxx(), r.miny());
+  coord_t ul(r.minx(), r.maxy());
+  coord_t ur(r.maxx(), r.maxy());
+  coord_t ll(r.minx(), r.miny());
+  coord_t lr(r.maxx(), r.miny());
   if (Contains(ul) && Contains(ur) && Contains(ll) && Contains(lr))
     return kContains;
 
   // Test if any of the rectangle edges intersect
-  Point2 pt0, pt1;
-  LineSegment2 bottom(ll, lr);
+  coord_t pt0, pt1;
+  LineSegment2<coord_t> bottom(ll, lr);
   if (Intersect(bottom, pt0, pt1) > 0)
     return kIntersects;
 
-  LineSegment2 top(ul, ur);
+  LineSegment2<coord_t> top(ul, ur);
   if (Intersect(top, pt0, pt1) > 0)
     return kIntersects;
 
-  LineSegment2 left(ll, ul);
+  LineSegment2<coord_t> left(ll, ul);
   if (Intersect(left, pt0, pt1) > 0)
     return kIntersects;
 
-  LineSegment2 right(lr, ur);
+  LineSegment2<coord_t> right(lr, ur);
   if (Intersect(right, pt0, pt1) > 0)
     return kIntersects;
 
@@ -144,13 +148,18 @@ IntersectCase Ellipse::DoesIntersect(const AABB2& r) const {
 }
 
 // Tests if a point is inside the ellipse.
-bool Ellipse::Contains(const Point2& pt) const {
+template <class coord_t>
+bool Ellipse<coord_t>::Contains(const coord_t& pt) const {
   // Plug in equation for ellipse, If evaluates to <= 0 then the
   // point is in or on the ellipse.
   float dx = pt.x() - center_.x();
   float dy = pt.y() - center_.y();
   return (((k1_ * sqr(dx)) + (k2_ * dx * dy) + (k3_ * sqr(dy)) - 1) <= 0);
 }
+
+// Explicit instantiation
+template class Ellipse<Point2>;
+template class Ellipse<PointLL>;
 
 }
 }

--- a/src/midgard/linesegment2.cc
+++ b/src/midgard/linesegment2.cc
@@ -5,30 +5,36 @@ namespace valhalla {
 namespace midgard {
 
 // Default constructor.
-LineSegment2::LineSegment2() {
+template <class coord_t>
+LineSegment2<coord_t>::LineSegment2() {
   a_.Set(0.0f, 0.0f);
   b_.Set(0.0f, 0.0f);
 }
 
 // Constructor given 2 points.
-LineSegment2::LineSegment2(const Point2& p1, const Point2& p2) {
+template <class coord_t>
+LineSegment2<coord_t>::LineSegment2(const coord_t& p1, const coord_t& p2) {
   a_ = p1;
   b_ = p2;
 }
 
 // Get the first point of the segment.
-Point2 LineSegment2::a() const {
+template <class coord_t>
+coord_t LineSegment2<coord_t>::a() const {
   return a_;
 }
 
 // Get the second point of the segment.
-Point2 LineSegment2::b() const {
+template <class coord_t>
+coord_t LineSegment2<coord_t>::b() const {
   return b_;
 }
 
 // Finds the distance squared of a specified point from the line segment
 // and the closest point on the segment to the specified point.
-float LineSegment2::DistanceSquared(const Point2& p, Point2& closest) const {
+template <class coord_t>
+float LineSegment2<coord_t>::DistanceSquared(const coord_t& p,
+                                             coord_t& closest) const {
   // Construct vector v (ab) and w (ap)
   Vector2 v(a_, b_);
   Vector2 w(a_, p);
@@ -58,15 +64,18 @@ float LineSegment2::DistanceSquared(const Point2& p, Point2& closest) const {
 
 // Finds the distance of a specified point from the line segment
 // and the closest point on the segment to the specified point.
-float LineSegment2::Distance(const Point2& p, Point2& closest) const {
+template <class coord_t>
+float LineSegment2<coord_t>::Distance(const coord_t& p,
+                                      coord_t& closest) const {
   return sqrtf(DistanceSquared(p, closest));
 }
 
 // Determines if the current segment intersects the specified segment.
 // If an intersect occurs the intersection is computed.  Note: the
 // case where the lines overlap is not considered.
-bool LineSegment2::Intersect(const LineSegment2& segment,
-             Point2& intersect) const {
+template <class coord_t>
+bool LineSegment2<coord_t>::Intersect(const LineSegment2<coord_t>& segment,
+             coord_t& intersect) const {
   // Construct vectors
   Vector2 b = b_ - a_;
   Vector2 d = segment.b() - segment.a();
@@ -97,7 +106,8 @@ bool LineSegment2::Intersect(const LineSegment2& segment,
 }
 
 // Determines if the line segment intersects specified convex polygon.
-bool LineSegment2::Intersect(const std::vector<Point2>& poly) const {
+template <class coord_t>
+bool LineSegment2<coord_t>::Intersect(const std::vector<coord_t>& poly) const {
   // Initialize the candidate interval
   float t_out = 1.0f;
   float t_in  = 0.0f;
@@ -148,8 +158,9 @@ bool LineSegment2::Intersect(const std::vector<Point2>& poly) const {
 }
 
 // Clips the line segment to a specified convex polygon.
-bool LineSegment2::ClipToPolygon(const std::vector<Point2>& poly,
-                   LineSegment2& clip_segment) const {
+template <class coord_t>
+bool LineSegment2<coord_t>::ClipToPolygon(const std::vector<coord_t>& poly,
+                   LineSegment2<coord_t>& clip_segment) const {
   // Initialize the candidate interval
   float t_out = 1.0f;
   float t_in  = 0.0f;
@@ -203,10 +214,15 @@ bool LineSegment2::ClipToPolygon(const std::vector<Point2>& poly,
 }
 
 // Tests if a point is to left, right, or on the line segment.
-float LineSegment2::IsLeft(const Point2& p) const {
-  return (b_.x() - a_.x()) * (p.y() - a_.y()) -
-         (p.x() - a_.x()) * (b_.y() - a_.y());
+template <class coord_t>
+float LineSegment2<coord_t>::IsLeft(const coord_t& p) const {
+  return (b_.x() - a_.x()) * (p.y()  - a_.y()) -
+         (p.x()  - a_.x()) * (b_.y() - a_.y());
 }
+
+// Explicit instantiation
+template class LineSegment2<Point2>;
+template class LineSegment2<PointLL>;
 
 }
 }

--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -1,24 +1,30 @@
 #include "valhalla/midgard/polyline2.h"
 
-namespace valhalla{
-namespace midgard{
+#include <vector>
 
-Polyline2::Polyline2() { }
+namespace valhalla {
+namespace midgard {
+
+template <class coord_t>
+Polyline2<coord_t>::Polyline2() { }
 
 // Constructor given a list of points.
-Polyline2::Polyline2(std::vector<Point2>& pts) {
+template <class coord_t>
+Polyline2<coord_t>::Polyline2(std::vector<coord_t>& pts) {
   pts_ = pts;
 }
 
 // Get the list of points.
-std::vector<Point2>& Polyline2::pts() {
+template <class coord_t>
+std::vector<coord_t>& Polyline2<coord_t>::pts() {
   return pts_;
 }
 
 // Add a point to the polyline. Checks to see if the input point is
 // equal to the current endpoint of the polyline and does not add the
 // point if it is equal.
-void Polyline2::Add(const Point2& p) {
+template <class coord_t>
+void Polyline2<coord_t>::Add(const coord_t& p) {
   uint32_t n = pts_.size();
   if (n == 0 || !(p == pts_[n-1]))
     pts_.push_back(p);
@@ -26,7 +32,8 @@ void Polyline2::Add(const Point2& p) {
 
 // Finds the length of the polyline by accumulating the length of all
 // segments.
-float Polyline2::Length() const {
+template <class coord_t>
+float Polyline2<coord_t>::Length() const {
   float length = 0;
   for (uint32_t i = 0; i < pts_.size() - 1; i++) {
     length += pts_[i].Distance(pts_[i+1]);
@@ -35,7 +42,8 @@ float Polyline2::Length() const {
 }
 
 // Find the length of the supplied polyline.
-float Polyline2::Length(const std::vector<Point2>& pts) const {
+template <class coord_t>
+float Polyline2<coord_t>::Length(const std::vector<coord_t>& pts) const {
   float length = 0;
   for (uint32_t i = 0; i < pts_.size() - 1; i++) {
     length += pts[i].Distance(pts[i+1]);
@@ -45,16 +53,18 @@ float Polyline2::Length(const std::vector<Point2>& pts) const {
 
 // Finds the closest point to the supplied polyline as well as the distance
 // squared to that point and the index of the segment where the closest point lies.
-std::tuple<Point2, float, int> Polyline2::ClosestPoint(const Point2& pt) const {
+template <class coord_t>
+std::tuple<coord_t, float, int> Polyline2<coord_t>::ClosestPoint(const coord_t& pt) const {
   return pt.ClosestPoint(pts_);
 }
 
 // Generalize this polyline.
-uint32_t Polyline2::Generalize(const float t) {
+template <class coord_t>
+uint32_t Polyline2<coord_t>::Generalize(const float t) {
   // Create a vector for the output shape. Recursively call Douglass-Peucker
   // method to generalize the polyline. Square the error tolerance to avoid
   // sqrts.
-  std::vector<Point2> genpts;
+  std::vector<coord_t> genpts;
   DouglasPeucker(0, pts_.size() - 1, t*t, genpts);
   pts_= genpts;
   return pts_.size();
@@ -62,38 +72,46 @@ uint32_t Polyline2::Generalize(const float t) {
 
 // Get a generalized polyline from this polyline. This polyline remains
 // unchanged.
-Polyline2 Polyline2::GeneralizedPolyline(const float t) {
+template <class coord_t>
+Polyline2<coord_t> Polyline2<coord_t>::GeneralizedPolyline(const float t) {
   // Recursively call Douglass-Peucker method to generalize the polyline.
   // Square the error tolerance to avoid sqrts.
-  std::vector<Point2> genpts;
+  std::vector<coord_t> genpts;
   DouglasPeucker(0, pts_.size() - 1, t * t, genpts);
   return Polyline2(genpts);
 }
 
 // Clip this polyline to the specified bounding box.
-uint32_t Polyline2::Clip(const AABB2& box) {
-  Clipper2 clipper;
+template <class coord_t>
+uint32_t Polyline2<coord_t>::Clip(const AABB2<coord_t>& box) {
+  Clipper2<coord_t> clipper;
   return clipper.Clip(box, pts_, false);
 }
 
 // Gets a polyline clipped to the supplied bounding box. This polyline
 // remains unchanged.
-Polyline2 Polyline2::ClippedPolyline(const AABB2& box) {
+template <class coord_t>
+Polyline2<coord_t> Polyline2<coord_t>::ClippedPolyline(const AABB2<coord_t>& box) {
   // Copy the polyline points to a temporary vector
-  Clipper2 clipper;
-  std::vector<Point2> pts = pts_;
+  Clipper2<coord_t> clipper;
+  std::vector<coord_t> pts = pts_;
   clipper.Clip(box, pts, false);
   return Polyline2(pts);
 }
 
-void Polyline2::DouglasPeucker(const uint32_t i, const uint32_t j,
-                    const float t2, std::vector<Point2>& genpts) {
+// Douglass-Peucker generalization. Finds the vertex farthest from the
+// segment between vertices i and j and checks if this distance exceeds
+// the tolerance. If the distance is less than the tolerance the segment
+// i,j is added to the output list of generalized vertices.
+template <class coord_t>
+void Polyline2<coord_t>::DouglasPeucker(const uint32_t i, const uint32_t j,
+                    const float t2, std::vector<coord_t>& genpts) {
   // Find the vertex farthest from the line segment ViVj
   uint32_t index = 0;
   float maxdist = 0.0f;
   float d2;
-  Point2 tmp;
-  LineSegment2 v(pts_[i], pts_[j]);
+  coord_t tmp;
+  LineSegment2<coord_t> v(pts_[i], pts_[j]);
   for (uint32_t k = i+1; k < j; k++) {
     // Get the squared distance from the intermediate point to the segment
     d2 = v.DistanceSquared(pts_[k], tmp);
@@ -122,6 +140,10 @@ void Polyline2::DouglasPeucker(const uint32_t i, const uint32_t j,
     }
   }
 }
+
+// Explicit instantiation
+template class Polyline2<Point2>;
+template class Polyline2<PointLL>;
 
 }
 }

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -1,11 +1,14 @@
 #include "midgard/tiles.h"
-#include "midgard/distanceapproximator.h"
 #include <cmath>
 
 namespace valhalla {
 namespace midgard {
 
-Tiles::Tiles(const AABB2& bounds, const float tilesize) {
+// Constructor.  A bounding box and tile size is specified.
+// Sets class data members and computes the number of rows and columns
+// based on the bounding box and tile size.
+template <class coord_t>
+Tiles<coord_t>::Tiles(const AABB2<coord_t>& bounds, const float tilesize) {
   tilebounds_ = bounds;
   tilesize_ = tilesize;
   ncolumns_ = static_cast<int32_t>(ceil((bounds.maxx() - bounds.minx()) /
@@ -14,25 +17,33 @@ Tiles::Tiles(const AABB2& bounds, const float tilesize) {
                                         tilesize_));
 }
 
-float Tiles::TileSize() const {
+// Get the tile size. Tiles are square.
+template <class coord_t>
+float Tiles<coord_t>::TileSize() const {
   return tilesize_;
 }
 
-AABB2 Tiles::TileBounds() const {
+// Get the bounding box of the tiling system.
+template <class coord_t>
+AABB2<coord_t> Tiles<coord_t>::TileBounds() const {
   return tilebounds_;
 }
 
 // Get the number of rows in the tiling system.
-int32_t Tiles::nrows() const {
+template <class coord_t>
+int32_t Tiles<coord_t>::nrows() const {
   return nrows_;
 }
 
 // Get the number of columns in the tiling system.
-int32_t Tiles::ncolumns() const {
+template <class coord_t>
+int32_t Tiles<coord_t>::ncolumns() const {
   return ncolumns_;
 }
 
-int32_t Tiles::Row(const float y) const {
+// Get the "row" based on y.
+template <class coord_t>
+int32_t Tiles<coord_t>::Row(const float y) const {
   // Return -1 if outside the tile system bounds
   if (y < tilebounds_.miny() || y > tilebounds_.maxy())
     return -1;
@@ -45,7 +56,9 @@ int32_t Tiles::Row(const float y) const {
   }
 }
 
-int32_t Tiles::Col(const float x) const {
+// Get the "column" based on x.
+template <class coord_t>
+int32_t Tiles<coord_t>::Col(const float x) const {
   // Return -1 if outside the tile system bounds
   if (x < tilebounds_.minx() || x > tilebounds_.maxx())
     return -1;
@@ -60,11 +73,15 @@ int32_t Tiles::Col(const float x) const {
   }
 }
 
-int32_t Tiles::TileId(const Point2& c) const {
+// Convert a coordinate into a tile Id. The point is within the tile.
+template <class coord_t>
+int32_t Tiles<coord_t>::TileId(const coord_t& c) const {
   return TileId(c.y(), c.x());
 }
 
-int32_t Tiles::TileId(const float y, const float x) const {
+// Convert x,y to a tile Id.
+template <class coord_t>
+int32_t Tiles<coord_t>::TileId(const float y, const float x) const {
   // Return -1 if totally outside the extent.
   if (y < tilebounds_.miny() || x < tilebounds_.minx() ||
       y > tilebounds_.maxy() || x > tilebounds_.maxx())
@@ -74,153 +91,195 @@ int32_t Tiles::TileId(const float y, const float x) const {
   return (Row(y) * ncolumns_) + Col(x);
 }
 
-int32_t Tiles::TileId(const int32_t col, const int32_t row) const {
+// Get the tile Id given the row Id and column Id.
+template <class coord_t>
+int32_t Tiles<coord_t>::TileId(const int32_t col, const int32_t row) const {
   return (row * ncolumns_) + col;
 }
 
 // Get the tile row, col based on tile Id.
-std::pair<int32_t, int32_t> Tiles::GetRowColumn(const int32_t tileid) const {
+template <class coord_t>
+std::pair<int32_t, int32_t> Tiles<coord_t>::GetRowColumn(
+                        const int32_t tileid) const {
   return { tileid / ncolumns_, tileid % ncolumns_ };
 }
 
-uint32_t Tiles::MaxTileId(const AABB2& bounds, const float tile_size) {
-  uint32_t cols = static_cast<uint32_t>(std::ceil(bounds.Width() / tile_size));
-  uint32_t rows = static_cast<uint32_t>(std::ceil(bounds.Height() / tile_size));
+// Get a maximum tileid given a bounds and a tile size.
+template <class coord_t>
+uint32_t Tiles<coord_t>::MaxTileId(const AABB2<coord_t>& bbox,
+                                   const float tile_size) {
+  uint32_t cols = static_cast<uint32_t>(std::ceil(bbox.Width() / tile_size));
+  uint32_t rows = static_cast<uint32_t>(std::ceil(bbox.Height() / tile_size));
   return (cols * rows) - 1;
 }
 
-Point2 Tiles::Base(const int32_t tileid) const {
+// Get the base x,y (or lat,lng) of a specified tile.
+template <class coord_t>
+coord_t Tiles<coord_t>::Base(const int32_t tileid) const {
   int32_t row = tileid / ncolumns_;
   int32_t col = tileid - (row * ncolumns_);
-  return Point2(tilebounds_.miny() + (row * tilesize_),
-                tilebounds_.minx() + (col * tilesize_));
+  return coord_t(tilebounds_.miny() + (row * tilesize_),
+                 tilebounds_.minx() + (col * tilesize_));
 }
 
-AABB2 Tiles::TileBounds(const int32_t tileid) const {
+// Get the bounding box of the specified tile.
+template <class coord_t>
+AABB2<coord_t> Tiles<coord_t>::TileBounds(const int32_t tileid) const {
   Point2 base = Base(tileid);
-  return AABB2(base.y(), base.x(), base.y() + tilesize_, base.x() + tilesize_);
+  return AABB2<coord_t>(base.y(), base.x(),
+                        base.y() + tilesize_, base.x() + tilesize_);
 }
 
-AABB2 Tiles::TileBounds(const int32_t col, const int32_t row) const {
+// Get the bounding box of the tile with specified row, column.
+template <class coord_t>
+AABB2<coord_t> Tiles<coord_t>::TileBounds(const int32_t col,
+                                          const int32_t row) const {
   float basey = ((float) row * tilesize_) + tilebounds_.miny();
   float basex = ((float) col * tilesize_) + tilebounds_.minx();
-  return AABB2(basey, basex, basey + tilesize_, basex + tilesize_);
+  return AABB2<coord_t>(basey, basex, basey + tilesize_, basex + tilesize_);
 }
 
-// Get the tile area in square kilometers.
-float Tiles::Area(const int32_t tileid) const {
-  AABB2 bb = TileBounds(tileid);
-  return ((bb.maxy() - bb.miny()) * kMetersPerDegreeLat * kKmPerMeter) *
-         ((bb.maxx() - bb.minx()) *
-             DistanceApproximator::MetersPerLngDegree(bb.Center().y()) * kKmPerMeter);
-}
-
-Point2 Tiles::Center(const int32_t tileid) const {
+// Get the center of the specified tile.
+template <class coord_t>
+coord_t Tiles<coord_t>::Center(const int32_t tileid) const {
   Point2 base = Base(tileid);
-  return Point2(base.y() + tilesize_ * 0.5, base.x() + tilesize_ * 0.5);
+  return coord_t(base.y() + tilesize_ * 0.5, base.x() + tilesize_ * 0.5);
 }
 
-int32_t Tiles::GetRelativeTileId(const int32_t initial_tile, const int32_t delta_rows,
+// Get the tile Id given a previous tile and a row, column offset.
+template <class coord_t>
+int32_t Tiles<coord_t>::GetRelativeTileId(const int32_t initial_tile,
+                             const int32_t delta_rows,
                              const int32_t delta_cols) const {
   return initial_tile + (delta_rows * ncolumns_) + delta_cols;
 }
 
-void Tiles::TileOffsets(const int32_t initial_tileid, const int32_t newtileid,
+// Get the tile offsets (row,column) between the previous tile Id and
+// a new tileid.  The offsets are returned through arguments (references).
+// Offsets can be positive or negative or 0.
+template <class coord_t>
+void Tiles<coord_t>::TileOffsets(const int32_t initial_tileid, const int32_t newtileid,
                         int& delta_rows, int& delta_cols) const {
   int32_t deltaTile = newtileid - initial_tileid;
   delta_rows = (newtileid / ncolumns_) - (initial_tileid / ncolumns_);
   delta_cols = deltaTile - (delta_rows * ncolumns_);
 }
 
-uint32_t Tiles::TileCount() const {
+// Get the number of tiles in the tiling system.
+template <class coord_t>
+uint32_t Tiles<coord_t>::TileCount() const {
   float nrows = (tilebounds_.maxy() - tilebounds_.miny()) / tilesize_;
   return ncolumns_ * static_cast<int32_t>(ceil(nrows));
 }
 
-int32_t Tiles::RightNeighbor(const int32_t tileid) const {
+// Get the neighboring tileid to the right/east.
+template <class coord_t>
+int32_t Tiles<coord_t>::RightNeighbor(const int32_t tileid) const {
   int32_t row = tileid / ncolumns_;
   int32_t col = tileid - (row * ncolumns_);
   return (col < ncolumns_ - 1) ? tileid + 1 : tileid - ncolumns_ + 1;
 }
 
-int32_t Tiles::LeftNeighbor(const int32_t tileid) const {
+// Get the neighboring tileid to the left/west.
+template <class coord_t>
+int32_t Tiles<coord_t>::LeftNeighbor(const int32_t tileid) const {
   int32_t row = tileid / ncolumns_;
   int32_t col = tileid - (row * ncolumns_);
   return (col > 0) ? tileid - 1 : tileid + ncolumns_ - 1;
 }
 
-int32_t Tiles::TopNeighbor(const int32_t tileid) const {
+// Get the neighboring tileid above or north.
+template <class coord_t>
+int32_t Tiles<coord_t>::TopNeighbor(const int32_t tileid) const {
   return (tileid < static_cast<int32_t>((TileCount() - ncolumns_))) ?
               tileid + ncolumns_ : tileid;
 }
 
-int32_t Tiles::BottomNeighbor(const int32_t tileid) const {
+// Get the neighboring tileid below or south.
+template <class coord_t>
+int32_t Tiles<coord_t>::BottomNeighbor(const int32_t tileid) const {
   return (tileid < ncolumns_) ? tileid : tileid - ncolumns_;
 }
 
 // Checks if 2 tiles are neighbors (N,E,S,W).
-bool Tiles::AreNeighbors(const uint32_t id1, const uint32_t id2) const {
+template <class coord_t>
+bool Tiles<coord_t>::AreNeighbors(const uint32_t id1, const uint32_t id2) const {
   return (id2 == TopNeighbor(id1) ||
           id2 == RightNeighbor(id1) ||
           id2 == BottomNeighbor(id1) ||
           id2 == LeftNeighbor(id1));
 }
 
-const std::vector<int>& Tiles::TileList(const AABB2& boundingbox) {
-  // Clear lists
-  checklist_.clear();
-  tilelist_.clear();
-  visitedtiles_.clear();
-
+// Get the list of tiles that lie within the specified bounding box.
+// The method finds the center tile and spirals out by finding neighbors
+// and recursively checking if tile is inside and checking/adding
+// neighboring tiles
+template <class coord_t>
+const std::vector<int>& Tiles<coord_t>::TileList(
+              const AABB2<coord_t>& boundingbox) {
   // Get tile at the center of the bounding box. Return -1 if the center
   // of the bounding box is not within the tiling system bounding box.
   // TODO - relax this to check edges of the bounding box?
+  tilelist_.clear();
   int32_t tileid = TileId(boundingbox.Center());
   if (tileid == -1)
     return tilelist_;
 
+  // List of tiles to check if in view. Use a list: push new entries on the
+  // back and pop off the front. The tile search tends to spiral out from
+  // the center.
+  std::list<int32_t> checklist;
+
+  // Visited tiles
+  std::unordered_set<int32_t> visited_tiles;
+
   // Set this tile in the checklist and it to the list of visited tiles.
-  checklist_.push_back(tileid);
-  visitedtiles_.insert(tileid);
+  checklist.push_back(tileid);
+  visited_tiles.insert(tileid);
 
   // Get neighboring tiles in bounding box until NextTile returns -1
   // or the maximum number specified is reached
-  while (!checklist_.empty()) {
+  while (!checklist.empty()) {
     // Get the element off the front of the list and add it to the tile list.
-    tileid = checklist_.front();
-    checklist_.pop_front();
+    tileid = checklist.front();
+    checklist.pop_front();
     tilelist_.push_back(tileid);
 
     // Check neighbors
     int32_t neighbor = LeftNeighbor(tileid);
-    if (visitedtiles_.find(neighbor) == visitedtiles_.end() &&
+    if (visited_tiles.find(neighbor) == visited_tiles.end() &&
         boundingbox.Intersects(TileBounds(neighbor))) {
-      checklist_.push_back(neighbor);
-      visitedtiles_.insert(neighbor);
+      checklist.push_back(neighbor);
+      visited_tiles.insert(neighbor);
     }
     neighbor = RightNeighbor(tileid);
-    if (visitedtiles_.find(neighbor) == visitedtiles_.end() &&
+    if (visited_tiles.find(neighbor) == visited_tiles.end() &&
         boundingbox.Intersects(TileBounds(neighbor))) {
-      checklist_.push_back(neighbor);
-      visitedtiles_.insert(neighbor);
+      checklist.push_back(neighbor);
+      visited_tiles.insert(neighbor);
     }
     neighbor = TopNeighbor(tileid);
-    if (visitedtiles_.find(neighbor) == visitedtiles_.end() &&
+    if (visited_tiles.find(neighbor) == visited_tiles.end() &&
         boundingbox.Intersects(TileBounds(neighbor))) {
-      checklist_.push_back(neighbor);
-      visitedtiles_.insert(neighbor);
+      checklist.push_back(neighbor);
+      visited_tiles.insert(neighbor);
     }
     neighbor = BottomNeighbor(tileid);
-    if (visitedtiles_.find(neighbor) == visitedtiles_.end() &&
+    if (visited_tiles.find(neighbor) == visited_tiles.end() &&
         boundingbox.Intersects(TileBounds(neighbor))) {
-      checklist_.push_back(neighbor);
-      visitedtiles_.insert(neighbor);
+      checklist.push_back(neighbor);
+      visited_tiles.insert(neighbor);
     }
   }
   return tilelist_;
 }
 
-void Tiles::ColorMap(std::unordered_map<uint32_t, size_t>& connectivity_map) const {
+// Color a "connectivity map" starting with a sparse map of uncolored tiles.
+// Any 2 tiles that have a connected path between them will have the same
+// value in the connectivity map.
+template <class coord_t>
+void Tiles<coord_t>::ColorMap(std::unordered_map<uint32_t,
+                              size_t>& connectivity_map) const {
   // Connectivity map - all connected regions will have a unique Id. If any 2
   // tile Ids have a different Id they are judged to be not-connected.
 
@@ -271,6 +330,10 @@ void Tiles::ColorMap(std::unordered_map<uint32_t, size_t>& connectivity_map) con
     color++;
   }
 }
+
+// Explicit instantiation
+template class Tiles<Point2>;
+template class Tiles<PointLL>;
 
 }
 }

--- a/test/aabb2.cc
+++ b/test/aabb2.cc
@@ -12,34 +12,34 @@ using namespace valhalla::midgard;
 
 namespace {
 
-void TryIntersectsBb(const AABB2& a, const AABB2& b) {
+void TryIntersectsBb(const AABB2<Point2>& a, const AABB2<Point2>& b) {
   if (!a.Intersects(b))
     throw runtime_error("Intersecting BB test failed");
 }
 
 void TestIntersectsBb() {
-  TryIntersectsBb(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
-                AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  TryIntersectsBb(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f),
+                AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryContainsBb(const AABB2& a, const AABB2& b) {
+void TryContainsBb(const AABB2<Point2>& a, const AABB2<Point2>& b) {
   if (!a.Contains(b))
     throw runtime_error("Contains BB test failed");
 }
 
 void TestContainsBb() {
-  TryContainsBb(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
-                AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  TryContainsBb(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f),
+                AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryIntesectsLn(const AABB2& box, const Point2& a,
+void TryIntesectsLn(const AABB2<Point2>& box, const Point2& a,
                     const Point2& b, bool expected) {
   if (box.Intersect(a, b) != expected)
     throw runtime_error("Intersects line test failed");
 }
 
 void TestIntersectsLn() {
-  AABB2 box(40.0f, -76.0f, 41.0f, -75.0f);
+  AABB2<Point2> box(40.0f, -76.0f, 41.0f, -75.0f);
 
   // Test with one or both points in the box
   TryIntesectsLn(box, Point2(40.5f, -75.5f), Point2(41.5f, -75.5f), true);
@@ -65,48 +65,48 @@ void TestIntersectsLn() {
   TryIntesectsLn(box, Point2(39.2f, -75.5f), Point2(40.5f, -74.5f), false);
 }
 
-void TryContainsPt(const AABB2& a, const AABB2& b) {
+void TryContainsPt(const AABB2<Point2>& a, const AABB2<Point2>& b) {
   if (!a.Contains(b.Center()))
     throw runtime_error("Contains point test failed");
 }
 
 void TestContainsPt() {
-  TryContainsPt(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
-                AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  TryContainsPt(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f),
+                AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryEquality(const AABB2& a, const AABB2& b) {
+void TryEquality(const AABB2<Point2>& a, const AABB2<Point2>& b) {
   if (a == b)
     throw runtime_error("Equality test failed");
 }
 
 void TestEquality() {
-  TryEquality(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
-                AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  TryEquality(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f),
+                AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryExpand(AABB2 a, const AABB2& b) {
+void TryExpand(AABB2<Point2> a, const AABB2<Point2>& b) {
   a.Expand(b);
   if (!(a == b))
     throw runtime_error("Expand test failed");
 }
 
 void TestExpand() {
-  TryExpand(AABB2(40.0f, -76.4f, 40.1f, -76.3f),
-            AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f));
+  TryExpand(AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f),
+            AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f));
 }
 
-void TryPtConstructor(const AABB2& a) {
-  AABB2 b = AABB2(a.minpt(), a.maxpt());
+void TryPtConstructor(const AABB2<Point2>& a) {
+  AABB2<Point2> b = AABB2<Point2>(a.minpt(), a.maxpt());
   if (!(a == b))
     throw runtime_error("Point Constructor test failed");
 }
 
 void TestPtConstructor() {
-  TryPtConstructor(AABB2(40.0f, -76.4f, 40.1f, -76.3f));
+  TryPtConstructor(AABB2<Point2>(40.0f, -76.4f, 40.1f, -76.3f));
 }
 
-void TryMinMaxValues(const AABB2& a, float minx_res, float maxx_res,
+void TryMinMaxValues(const AABB2<Point2>& a, float minx_res, float maxx_res,
                      float miny_res, float maxy_res) {
   if (fabs(a.minx() - minx_res) > kEpsilon)
     throw runtime_error("Min x value test failed");
@@ -122,48 +122,39 @@ void TryMinMaxValues(const AABB2& a, float minx_res, float maxx_res,
 }
 
 void TestMinMaxValues() {
-  TryMinMaxValues(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f),
+  TryMinMaxValues(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f),
                   39.8249f, 40.2559f, -76.8013f, -75.8997f);
 }
 
-void TryTestWidth(const AABB2& a, float res) {
+void TryTestWidth(const AABB2<Point2>& a, float res) {
   if (fabs(a.Width() - res) > kEpsilon)
     throw runtime_error("Width test failed");
 }
 
 void TestWidth() {
-  TryTestWidth(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f), 0.431f);
+  TryTestWidth(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f), 0.431f);
 }
 
-void TryTestHeight(const AABB2& a, float res) {
+void TryTestHeight(const AABB2<Point2>& a, float res) {
   if (fabs(a.Height() - res) > kEpsilon)
-    throw runtime_error("Area test failed");
+    throw runtime_error("Height test failed");
 }
 
 void TestHeight() {
-  TryTestHeight(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f), 0.901604f);
+  TryTestHeight(AABB2<Point2>(39.8249f, -76.8013f, 40.2559f, -75.8997f), 0.901604f);
 }
 
-void TryTestArea(const AABB2& a, float res) {
-  if (fabs(a.Area() - res) > kEpsilon)
-    throw runtime_error("Area test failed");
-}
+void TryTestVector(const AABB2<Point2>& a, std::vector<Point2>& pts) {
 
-void TestArea() {
-  TryTestArea(AABB2(39.8249f, -76.8013f, 40.2559f, -75.8997f), 0.388591f);
-}
-
-void TryTestVector(const AABB2& a, std::vector<Point2>& pts) {
-
-  AABB2 b(pts);
+  AABB2<Point2> b(pts);
   if (!(a == b))
     throw runtime_error("Test Vector test failed");
 }
 
 void TestVector() {
   std::vector<Point2> pts;
-  AABB2 a(39.8249f, -76.8013f, 40.2559f, -75.8997f);
-  AABB2 b(40.0f, -76.4f, 40.1f, -76.3f);
+  AABB2<Point2> a(39.8249f, -76.8013f, 40.2559f, -75.8997f);
+  AABB2<Point2> b(40.0f, -76.4f, 40.1f, -76.3f);
 
   pts.push_back(a.Center());
   pts.push_back(a.maxpt());
@@ -210,9 +201,6 @@ int main() {
 
   //Test height.
   suite.test(TEST_CASE(TestHeight));
-
-  //Test area.
-  suite.test(TEST_CASE(TestArea));
 
   //Test vector.
   suite.test(TEST_CASE(TestVector));

--- a/test/ellipse.cc
+++ b/test/ellipse.cc
@@ -1,10 +1,9 @@
+#include "valhalla/midgard/point2.h"
 #include "valhalla/midgard/ellipse.h"
 
 #include "test.h"
 
 #include <vector>
-
-#include "valhalla/midgard/point2.h"
 #include "valhalla/midgard/vector2.h"
 #include "valhalla/midgard/linesegment2.h"
 #include "valhalla/midgard/aabb2.h"
@@ -14,7 +13,7 @@ using namespace valhalla::midgard;
 
 namespace {
 
-void TryLineIntersection(const Ellipse& a, const LineSegment2& line, const uint32_t expected) {
+void TryLineIntersection(const Ellipse<Point2>& a, const LineSegment2<Point2>& line, const uint32_t expected) {
   Point2 p1, p2;
   if (a.Intersect(line, p1, p2) != expected) {
     throw runtime_error("Ellipse: LineSegment intersect test failed: expected: " +
@@ -23,15 +22,15 @@ void TryLineIntersection(const Ellipse& a, const LineSegment2& line, const uint3
 }
 
 void TestLineIntersection() {
-  Ellipse e({1,1}, {5,-1}, 45.0f);
+  Ellipse<Point2> e({1,1}, {5,-1}, 45.0f);
 
   // TODO - could check intersect points
-  TryLineIntersection(e, LineSegment2({-5,5}, {5,5}), 0);
-  TryLineIntersection(e, LineSegment2({-5,0}, {5,0}), 2);
-  TryLineIntersection(e, LineSegment2({3,0}, {3,5}), 1);
+  TryLineIntersection(e, LineSegment2<Point2>({-5,5}, {5,5}), 0);
+  TryLineIntersection(e, LineSegment2<Point2>({-5,0}, {5,0}), 2);
+  TryLineIntersection(e, LineSegment2<Point2>({3,0}, {3,5}), 1);
 }
 
-void TryAABBIntersection(const Ellipse& a, const AABB2& box, const IntersectCase expected) {
+void TryAABBIntersection(const Ellipse<Point2>& a, const AABB2<Point2>& box, const IntersectCase expected) {
   if (a.DoesIntersect(box) != expected) {
     throw runtime_error("Ellipse AABB2 does intersect test failed: expected: " +
                         std::to_string(expected));
@@ -39,23 +38,23 @@ void TryAABBIntersection(const Ellipse& a, const AABB2& box, const IntersectCase
 }
 
 void TestAABBIntersection() {
-  Ellipse e({1,1}, {5,-1}, 45.0f);
+  Ellipse<Point2> e({1,1}, {5,-1}, 45.0f);
 
   // Test for ellipse containing rectangle
-  TryAABBIntersection(e, AABB2({2.5f,-0.5f},{3.5f,0.5f}), IntersectCase::kContains);
+  TryAABBIntersection(e, AABB2<Point2>({2.5f,-0.5f},{3.5f,0.5f}), IntersectCase::kContains);
 
   // Test for ellipse within rectangle
-  TryAABBIntersection(e, AABB2({-2,-2},{6,3}), IntersectCase::kWithin);
+  TryAABBIntersection(e, AABB2<Point2>({-2,-2},{6,3}), IntersectCase::kWithin);
 
   // Test for rectangle outside ellipse
-  TryAABBIntersection(e, AABB2({-2,-2},{0,3}), IntersectCase::kOutside);
+  TryAABBIntersection(e, AABB2<Point2>({-2,-2},{0,3}), IntersectCase::kOutside);
 
   // Test for rectangle intersecting ellipse
-  TryAABBIntersection(e, AABB2({1,0},{3,1}), IntersectCase::kIntersects);
+  TryAABBIntersection(e, AABB2<Point2>({1,0},{3,1}), IntersectCase::kIntersects);
 }
 
 
-void TryContains(const Ellipse& a, const Point2& pt, const bool expected) {
+void TryContains(const Ellipse<Point2>& a, const Point2& pt, const bool expected) {
   if (a.Contains(pt) != expected) {
     throw runtime_error("Ellipse Contains test failed: expected: " +
                         std::to_string(expected));
@@ -63,7 +62,7 @@ void TryContains(const Ellipse& a, const Point2& pt, const bool expected) {
 }
 
 void TestContains() {
-  Ellipse e({1,1}, {5,-1}, 45.0f);
+  Ellipse<Point2> e({1,1}, {5,-1}, 45.0f);
   TryContains(e, {3,0}, true);
   TryContains(e, {1,0}, false);
   TryContains(e, {5,0}, false);

--- a/test/linesegment2.cc
+++ b/test/linesegment2.cc
@@ -11,7 +11,7 @@ using namespace valhalla::midgard;
 
 namespace {
 
-void TryDistance(const Point2& p, const LineSegment2& s, const float res,
+void TryDistance(const Point2& p, const LineSegment2<Point2>& s, const float res,
                  const Point2& exp) {
   Point2 closest;
   float d = s.Distance(p, closest);
@@ -25,7 +25,7 @@ void TestDistance() {
   // Test segment
   Point2 a(-2.0f, -2.0f);
   Point2 b( 4.0f, 4.0f);
-  LineSegment2 s1(a, b);
+  LineSegment2<Point2> s1(a, b);
 
   // Case 1 - point is "before start" of segment. a is closest
   TryDistance(Point2(-4.0f, -2.0f), s1, 2.0f, a);
@@ -37,7 +37,7 @@ void TestDistance() {
   TryDistance(Point2(0.0f, 2.0f), s1, sqrtf(2.0f), Point2(1.0f, 1.0f));
 }
 
-void TryIntersect(const LineSegment2& s1, const LineSegment2& s2,
+void TryIntersect(const LineSegment2<Point2>& s1, const LineSegment2<Point2>& s2,
                   const bool res, const Point2& exp) {
   Point2 intersect;
   bool doesintersect = s1.Intersect(s2, intersect);
@@ -47,31 +47,65 @@ void TryIntersect(const LineSegment2& s1, const LineSegment2& s2,
           fabs(intersect.y() - exp.y()) > kEpsilon))
     throw runtime_error("Intersect test failed - intersection point is incorrect");
 }
+
+void TryIntersectLL(const LineSegment2<PointLL>& s1, const LineSegment2<PointLL>& s2,
+                  const bool res, const PointLL& exp) {
+  PointLL intersect;
+  bool doesintersect = s1.Intersect(s2, intersect);
+  if (doesintersect != res)
+    throw runtime_error("Intersect test failed - intersects is incorrect");
+  if (doesintersect && (fabs(intersect.x() - exp.x()) > kEpsilon ||
+          fabs(intersect.y() - exp.y()) > kEpsilon))
+    throw runtime_error("Intersect test failed - intersection point is incorrect");
+}
+
 void TestIntersect() {
-  LineSegment2 s1(Point2(-2.0f, -2.0f), Point2(4.0f, 4.0f));
+  LineSegment2<Point2> s1(Point2(-2.0f, -2.0f), Point2(4.0f, 4.0f));
 
   // Case 1 - beyond end of s1
-  LineSegment2 s2(Point2(8.0f, 10.0f), Point2(4.0f, 2.0f));
+  LineSegment2<Point2> s2(Point2(8.0f, 10.0f), Point2(4.0f, 2.0f));
   TryIntersect(s1, s2, false, Point2(0.0f, 0.0f));
 
   // Case 2 - before start of s1
-  LineSegment2 s3(Point2(-10.0f, 5.0f), Point2(-14.0f, -5.0f));
+  LineSegment2<Point2> s3(Point2(-10.0f, 5.0f), Point2(-14.0f, -5.0f));
   TryIntersect(s1, s3, false, Point2(0.0f, 0.0f));
 
   // Case 3 - s1 beyond end of s4
-  LineSegment2 s4(Point2(0.0f, -5.0f), Point2(-1.0f, -2.0f));
+  LineSegment2<Point2> s4(Point2(0.0f, -5.0f), Point2(-1.0f, -2.0f));
   TryIntersect(s1, s4, false, Point2(0.0f, 0.0f));
 
   // Case 4 - s1 before start of s5
-  LineSegment2 s5(Point2(0.0f, 5.0f), Point2(1.0f, 3.0f));
+  LineSegment2<Point2> s5(Point2(0.0f, 5.0f), Point2(1.0f, 3.0f));
   TryIntersect(s1, s5, false, Point2(0.0f, 0.0f));
 
   // Case 3 - intersection
-  LineSegment2 s6(Point2(-2.0f, 2.0f), Point2(2.0f, -2.0f));
+  LineSegment2<Point2> s6(Point2(-2.0f, 2.0f), Point2(2.0f, -2.0f));
   TryIntersect(s1, s6, true, Point2(0.0f, 0.0f));
+
+  // Same cases with PointLL
+  // Case 1 - beyond end of s1
+  LineSegment2<PointLL> s1ll(PointLL(-2.0f, -2.0f), PointLL(4.0f, 4.0f));
+  LineSegment2<PointLL> s2ll(PointLL(8.0f, 10.0f), PointLL(4.0f, 2.0f));
+  TryIntersectLL(s1ll, s2ll, false, PointLL(0.0f, 0.0f));
+
+  // Case 2 - before start of s1
+  LineSegment2<PointLL> s3ll(PointLL(-10.0f, 5.0f), PointLL(-14.0f, -5.0f));
+  TryIntersectLL(s1ll, s3ll, false, PointLL(0.0f, 0.0f));
+
+  // Case 3 - s1 beyond end of s4
+  LineSegment2<PointLL> s4ll(PointLL(0.0f, -5.0f), PointLL(-1.0f, -2.0f));
+  TryIntersectLL(s1ll, s4ll, false, PointLL(0.0f, 0.0f));
+
+  // Case 4 - s1 before start of s5
+  LineSegment2<PointLL> s5ll(PointLL(0.0f, 5.0f), PointLL(1.0f, 3.0f));
+  TryIntersectLL(s1ll, s5ll, false, PointLL(0.0f, 0.0f));
+
+  // Case 3 - intersection
+  LineSegment2<PointLL> s6ll(PointLL(-2.0f, 2.0f), PointLL(2.0f, -2.0f));
+  TryIntersectLL(s1ll, s6ll, true, PointLL(0.0f, 0.0f));
 }
 
-void TryPolyIntersect(const LineSegment2& s1, const std::vector<Point2>& poly,
+void TryPolyIntersect(const LineSegment2<Point2>& s1, const std::vector<Point2>& poly,
                       const bool res) {
   if (s1.Intersect(poly) != res) {
     throw runtime_error("Polygon Intersect test failed");
@@ -90,31 +124,31 @@ void TestPolyIntersect() {
   };
 
   // First point inside
-  LineSegment2 s1(Point2(0.0f, 0.0f), Point2(4.0f, 12.0f));
+  LineSegment2<Point2> s1(Point2(0.0f, 0.0f), Point2(4.0f, 12.0f));
   TryPolyIntersect(s1, poly, true);
 
   // Second point inside
-  LineSegment2 s2(Point2(4.0f, 12.0f), Point2(0.0f, 0.0f));
+  LineSegment2<Point2> s2(Point2(4.0f, 12.0f), Point2(0.0f, 0.0f));
   TryPolyIntersect(s2, poly, true);
 
   // Segment parallel to an edge and outside
-  LineSegment2 s3(Point2(4.0f, -5.0f), Point2(4.0f, 5.0f));
+  LineSegment2<Point2> s3(Point2(4.0f, -5.0f), Point2(4.0f, 5.0f));
   TryPolyIntersect(s3, poly, false);
 
   // Passing through
-  LineSegment2 s4(Point2(-5.0f, -5.0f), Point2(5.0f, 5.0f));
+  LineSegment2<Point2> s4(Point2(-5.0f, -5.0f), Point2(5.0f, 5.0f));
   TryPolyIntersect(s4, poly, true);
 
   // No intersect with early out
-  LineSegment2 s5(Point2(-10.0f, 5.0f), Point2(2.0f, 5.0f));
+  LineSegment2<Point2> s5(Point2(-10.0f, 5.0f), Point2(2.0f, 5.0f));
   TryPolyIntersect(s5, poly, false);
 
   // Segment ends along an edge
-  LineSegment2 s6(Point2(10.0f, 5.0f), Point2(2.0f, 0.0f));
+  LineSegment2<Point2> s6(Point2(10.0f, 5.0f), Point2(2.0f, 0.0f));
   TryPolyIntersect(s6, poly, true);
 }
 
-void TryIsLeft(const Point2& p, const LineSegment2& s, const int res) {
+void TryIsLeft(const Point2& p, const LineSegment2<Point2>& s, const int res) {
   float d = s.IsLeft(p);
   if (res == 0 && fabs(d) > kEpsilon) {
     throw runtime_error("IsLeft test failed - should be on the segment");
@@ -129,7 +163,7 @@ void TryIsLeft(const Point2& p, const LineSegment2& s, const int res) {
 void TestIsLeft() {
   // Use -1 for right of the segment, 0 for on the segment, and 1 for left
   // of the segment
-  LineSegment2 s(Point2(-2.0f, -2.0f), Point2(4.0f, 4.0f));
+  LineSegment2<Point2> s(Point2(-2.0f, -2.0f), Point2(4.0f, 4.0f));
   TryIsLeft(Point2(2.0f, 2.0f), s, 0);  // Should be on the line segment
   TryIsLeft(Point2(0.0f, 2.0f), s, 1);  // Should be left of the segment
   TryIsLeft(Point2(2.0f, 0.0f), s, -1); // Should be right of the segment

--- a/test/polyline2.cc
+++ b/test/polyline2.cc
@@ -11,7 +11,7 @@ using namespace valhalla::midgard;
 
 namespace {
 
-void TryGeneralizeAndLength(Polyline2& pl, const float& gen, const float& res) {
+void TryGeneralizeAndLength(Polyline2<Point2>& pl, const float& gen, const float& res) {
   unsigned int size = pl.Generalize(gen);
 
   std::vector<Point2> pts = pl.pts();
@@ -23,7 +23,7 @@ void TryGeneralizeAndLength(Polyline2& pl, const float& gen, const float& res) {
     throw runtime_error("Generalize #2 test failed.");
   }
 
-  Polyline2 pl2;
+  Polyline2<Point2> pl2;
   pl2 = pl.GeneralizedPolyline(gen);
 
   if (pl2.pts().size() != 2)
@@ -41,11 +41,11 @@ void TryGeneralizeAndLength(Polyline2& pl, const float& gen, const float& res) {
 void TestGeneralizeAndLength() {
   std::vector<Point2> pts = { Point2(25.0f, 25.0f), Point2(50.0f, 50.0f),
       Point2(25.0f, 75.0f), Point2(50.0f, 100.0f) };
-  Polyline2 pl(pts);
+  Polyline2<Point2> pl(pts);
   TryGeneralizeAndLength(pl, 100.0f, 79.0569f);
 }
 
-void TryClosestPoint(const Polyline2& pl, const Point2& a, const Point2& b) {
+void TryClosestPoint(const Polyline2<Point2>& pl, const Point2& a, const Point2& b) {
 
   auto result = pl.ClosestPoint(a);
 
@@ -60,7 +60,7 @@ void TestClosestPoint() {
   Point2 d(50.0f, 100.0f);
 
   // Test adding points to polyline
-  Polyline2 pl;
+  Polyline2<Point2> pl;
   pl.Add(a);
   pl.Add(b);
   pl.Add(c);
@@ -76,7 +76,7 @@ void TestClosestPoint() {
   TryClosestPoint(pl, end, d);
 }
 
-void TryClip(Polyline2& pl, const AABB2& a, const unsigned int exp) {
+void TryClip(Polyline2<Point2>& pl, const AABB2<Point2>& a, const unsigned int exp) {
   // Clip and check vertex count and 1st 2 points
   unsigned int x = pl.Clip(a);
   if (x != exp)
@@ -91,16 +91,16 @@ void TryClip(Polyline2& pl, const AABB2& a, const unsigned int exp) {
 void TestClip() {
   std::vector<Point2> pts = { Point2(25.0f, 25.0f), Point2(50.0f, 50.0f),
       Point2(25.0f, 75.0f), Point2(50.0f, 100.0f) };
-  Polyline2 pl(pts);
-  TryClip(pl, AABB2(Point2(0.0f, 0.0f), Point2(75.0f, 50.0f)), 2);
+  Polyline2<Point2> pl(pts);
+  TryClip(pl, AABB2<Point2>(Point2(0.0f, 0.0f), Point2(75.0f, 50.0f)), 2);
 
   // Test with vertices on edges
-  Polyline2 pl2(pts);
-  TryClip(pl2, AABB2(Point2(25.0f, 25.0f), Point2(50.0f, 100.0f)), 4);
+  Polyline2<Point2> pl2(pts);
+  TryClip(pl2, AABB2<Point2>(Point2(25.0f, 25.0f), Point2(50.0f, 100.0f)), 4);
 }
 
-void TryClippedPolyline(Polyline2& pl, const AABB2& a, const unsigned int exp) {
-  Polyline2 pl2 = pl.ClippedPolyline(a);
+void TryClippedPolyline(Polyline2<Point2>& pl, const AABB2<Point2>& a, const unsigned int exp) {
+  Polyline2<Point2> pl2 = pl.ClippedPolyline(a);
   unsigned int x = pl2.pts().size();
   if (x != 2)
     throw runtime_error("ClippedPolyline test failed: count not correct");
@@ -115,8 +115,8 @@ void TryClippedPolyline(Polyline2& pl, const AABB2& a, const unsigned int exp) {
 void TestClippedPolyline() {
   std::vector<Point2> pts = { Point2(25.0f, 25.0f), Point2(50.0f, 50.0f),
       Point2(25.0f, 75.0f), Point2(50.0f, 100.0f) };
-  Polyline2 pl(pts);
-  TryClippedPolyline(pl, AABB2(Point2(0.0f, 0.0f), Point2(75.0f, 50.0f)), 2);
+  Polyline2<Point2> pl(pts);
+  TryClippedPolyline(pl, AABB2<Point2>(Point2(0.0f, 0.0f), Point2(75.0f, 50.0f)), 2);
 }
 
 }

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -10,18 +10,18 @@ using namespace valhalla::midgard;
 namespace {
 
 void TestMaxId() {
-  if(Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), .25) != 1036799)
+  if(Tiles<PointLL>::MaxTileId(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), .25) != 1036799)
     throw std::runtime_error("Unexpected maxid result");
-  if(Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), 1) != 64799)
+  if(Tiles<PointLL>::MaxTileId(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), 1) != 64799)
     throw std::runtime_error("Unexpected maxid result");
-  if(Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), 4) != 4049)
+  if(Tiles<PointLL>::MaxTileId(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), 4) != 4049)
     throw std::runtime_error("Unexpected maxid result");
-  if(Tiles::MaxTileId(AABB2(PointLL(-180, -90), PointLL(180, 90)), .33) != 595685)
+  if(Tiles<PointLL>::MaxTileId(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), .33) != 595685)
     throw std::runtime_error("Unexpected maxid result");
 }
 
 void TestRowCol() {
-  Tiles tiles(AABB2(PointLL(-180, -90), PointLL(180, 90)), 1);
+  Tiles<PointLL> tiles(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), 1);
 
   int32_t tileid1 = tiles.TileId(-76.5f, 40.5f);
   auto rc = tiles.GetRowColumn(tileid1);
@@ -32,7 +32,7 @@ void TestRowCol() {
 }
 
 void TestNeighbors() {
-  Tiles tiles(AABB2(PointLL(-180, -90), PointLL(180, 90)), 1);
+  Tiles<PointLL> tiles(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), 1);
 
   // Get a tile
   int32_t tileid1 = tiles.TileId(-76.5f, 40.5f);
@@ -80,9 +80,9 @@ void TestNeighbors() {
 }
 
 void TileList() {
-  Tiles tiles(AABB2(PointLL(-180, -90), PointLL(180, 90)), 1);
+  Tiles<PointLL> tiles(AABB2<PointLL>(PointLL(-180, -90), PointLL(180, 90)), 1);
 
-  AABB2 bbox(PointLL(-99.5f, 30.5f), PointLL(-90.5f, 39.5f));
+  AABB2<PointLL> bbox(PointLL(-99.5f, 30.5f), PointLL(-90.5f, 39.5f));
   std::vector<int32_t> tilelist = tiles.TileList(bbox);
   if (tilelist.size() != 100) {
     throw std::runtime_error("Wrong number of tiles " +

--- a/valhalla/midgard/aabb2.h
+++ b/valhalla/midgard/aabb2.h
@@ -4,14 +4,17 @@
 #include <vector>
 
 #include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/linesegment2.h>
 
 namespace valhalla {
 namespace midgard {
 
 /**
- * Axis Aligned Bounding Box (2 dimensional)
+ * Axis Aligned Bounding Box (2 dimensional). This is a template class that
+ * works with Point2 (Euclidean x,y) or PointLL (latitude,longitude).
  */
+template <class coord_t>
 class AABB2 {
  public:
   /**
@@ -24,7 +27,7 @@ class AABB2 {
    * @param  minpt  Minimum point (x,y)
    * @param  maxpt  Maximum point (x,y)
    */
-  AABB2(const Point2& minpt, const Point2& maxpt);
+  AABB2(const coord_t& minpt, const coord_t& maxpt);
 
   /**
    * Constructor with specified bounds.
@@ -40,7 +43,7 @@ class AABB2 {
    * Construct an AABB given a list of points.
    * @param  pts  Vertex list.
    */
-  AABB2(std::vector<Point2>& pts);
+  AABB2(const std::vector<coord_t>& pts);
 
   /**
    * Equality operator.
@@ -76,33 +79,35 @@ class AABB2 {
    * Get the point at the minimum x,y.
    * @return  Returns the min. point.
    */
-  Point2 minpt() const;
+  coord_t minpt() const;
 
   /**
    * Get the point at the maximum x,y.
    * @return  Returns the max. point.
    */
-  Point2 maxpt() const;
+  coord_t maxpt() const;
 
   /**
    * Creates an AABB given a list of points.
    * @param  pts  Vertex list.
    */
-  void Create(const std::vector<Point2>& pts);
+  void Create(const std::vector<coord_t>& pts);
 
   /**
    * Gets the center of the bounding box.
    * @return  Returns the center point of the bounding box.
    */
-  Point2 Center() const;
+  coord_t Center() const;
 
   /**
    * Tests if a specified point is within the bounding box.
-   * @param  pt   Point to test.
-   * @return  true if within the bounding box and false if outside the extent.
-   *          If the point lies along the minimum x,yx or y.
+   * @param   pt   Point to test.
+   * @return  Returns true if within the bounding box and false if outside
+   *          the extent. Points that lie along the minimum x or y edge are
+   *          considered to be inside, while points that lie on the maximum
+   *          x or y edge are considered to be outside.
    */
-  bool Contains(const Point2& pt) const;
+  bool Contains(const coord_t& pt) const;
 
   /**
    * Checks to determine if another bounding box is completely inside this
@@ -126,7 +131,7 @@ class AABB2 {
    * @return  Returns true if the segment intersects (or lies completely
    *          within) the bounding box.
    */
-  bool Intersect(const LineSegment2& seg) const;
+  bool Intersect(const LineSegment2<coord_t>& seg) const;
 
   /**
    * Tests whether the segment intersects the bounding box.
@@ -135,7 +140,7 @@ class AABB2 {
    * @return  Returns true if the segment intersects (or lies completely
    *          within) the bounding box.
    */
-  bool Intersect(const Point2& a, const Point2& b) const;
+  bool Intersect(const coord_t& a, const coord_t& b) const;
 
   /**
    * Gets the width of the bounding box.
@@ -150,15 +155,9 @@ class AABB2 {
   float Height() const;
 
   /**
-   * Gets the area of the bounding box.
-   * @return  Returns the area of the bounding box.
-   */
-  float Area() const;
-
-  /**
    * Expands (if necessary) the bounding box to include the specified
    * bounding box.
-   * @param  r2  Bounding bounding box to "combine" with this
+   * @param  r2  Bounding bounding box to "combine" with this bounding box.
    */
   void Expand(const AABB2& r2);
 

--- a/valhalla/midgard/clipper2.h
+++ b/valhalla/midgard/clipper2.h
@@ -3,16 +3,19 @@
 
 #include <vector>
 
-#include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/aabb2.h>
 
-namespace valhalla{
-namespace midgard{
+namespace valhalla {
+namespace midgard {
 
 /**
  * Clipping support. Clips a polygon or polyline to a rectangular
- * boundary.
+ * boundary. This is a template class that works with Point2
+ * (Euclidean x,y) or PointLL (latitude,longitude).
  */
+template <class coord_t>
 class Clipper2 {
  public:
   /**
@@ -26,7 +29,7 @@ class Clipper2 {
    *           0 vertices if none of the input polyline intersects or lies
    *           within the boundary.
    */
-  uint32_t Clip(const AABB2& bbox, std::vector<Point2>& pts,
+  uint32_t Clip(const AABB2<coord_t>& bbox, std::vector<coord_t>& pts,
                 const bool closed);
 
  private:
@@ -49,8 +52,8 @@ class Clipper2 {
    *          of vertices is in vout.
    */
   uint32_t ClipAgainstEdge(const ClipEdge edge, const bool closed,
-            const std::vector<Point2>& vin,
-            std::vector<Point2>& vout);
+            const std::vector<coord_t>& vin,
+            std::vector<coord_t>& vout);
 
   /**
    * Finds the intersection of the segment from insidept to outsidept with the
@@ -58,11 +61,11 @@ class Clipper2 {
    * line equation.
    * @param  edge  Edge to intersect.
    * @param  insidept  Vertex inside with respect to the edge.
-   * @param  outsidept Vertex outside with repsect to the edge.
+   * @param  outsidept Vertex outside with respect to the edge.
    * @return  Returns the intersection of the segment with the edge.
    */
-  Point2 ClipIntersection(const ClipEdge edge, const Point2& insidept,
-                          const Point2& outsidept);
+  coord_t ClipIntersection(const ClipEdge edge, const coord_t& insidept,
+                          const coord_t& outsidept);
 
   /**
    * Tests if the vertex is inside the rectangular boundary with respect to
@@ -72,14 +75,14 @@ class Clipper2 {
    * @return  Returns true if the point is inside with respect to the edge,
    *          false if it is outside.
    */
-  bool Inside(const ClipEdge edge, const Point2& v) const;
+  bool Inside(const ClipEdge edge, const coord_t& v) const;
 
   /**
    * Adds a vertex to the output vector if not equal to the prior.
    * @param  pt    Vertex to add.
    * @param  vout  Vertex list.
    */
-  void Add(const Point2& pt, std::vector<Point2>& vout);
+  void Add(const coord_t& pt, std::vector<coord_t>& vout);
 };
 
 }

--- a/valhalla/midgard/ellipse.h
+++ b/valhalla/midgard/ellipse.h
@@ -3,9 +3,10 @@
 
 #include <math.h>
 
+#include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/linesegment2.h>
-#include <valhalla/midgard/point2.h>
 #include <valhalla/midgard/util.h>
 
 namespace valhalla {
@@ -14,8 +15,10 @@ namespace midgard {
 /**
  * Ellipse. Methods to construct an ellipse, test if a line segment intersects,
  * an axis-aligned bounding box intersects, and whether a point is within the
- * ellipse.
+ * ellipse. Template class to work with Point2 (Euclidean x,y) or PointLL
+ * (latitude,longitude).
  */
+template <class coord_t>
 class Ellipse {
  public:
   /**
@@ -29,7 +32,7 @@ class Ellipse {
    * @param  p2     Another corner point of the bounding rectangle.
    * @param  angle  Angle of rotation
    */
-  Ellipse(const Point2& p1, const Point2& p2, float angle);
+  Ellipse(const coord_t& p1, const coord_t& p2, float angle);
 
   /**
    * Determines if a line segment intersects the ellipse and if so
@@ -39,12 +42,12 @@ class Ellipse {
    * @param    pt1      OUT - second intersection point (if it exists)
    * @return   Returns the number of intersection points (0, 1, or 2).
    */
-  uint32_t Intersect(const LineSegment2& seg, Point2& pt0,
-                         Point2& pt1) const;
+  uint32_t Intersect(const LineSegment2<coord_t>& seg, coord_t& pt0,
+                     coord_t& pt1) const;
 
   /**
    * Does the specified axis-aligned bounding box (rectangle) intersect
-   * this ellipse.
+   * this ellipse?
    * @param  r  Rectangle to intersect.
    * @return Returns the intersection case.
    *                 kContains   - Ellipse fully contains the AABB
@@ -52,7 +55,7 @@ class Ellipse {
    *                 kWithin     - Ellipse is fully within the AABB
    *                 kOutside    - Ellipse is fully outside the AABB
    */
-  IntersectCase DoesIntersect(const AABB2& r) const;
+  IntersectCase DoesIntersect(const AABB2<coord_t>& r) const;
 
   /**
    * Tests if a point is inside the ellipse.
@@ -60,10 +63,10 @@ class Ellipse {
    * @return  Returns true if the point is on or inside the ellipse,
    *          false if outside the ellipse.
    */
-  bool Contains(const Point2& pt) const;
+  bool Contains(const coord_t& pt) const;
 
  private:
-  Point2 center_;
+  coord_t center_;
   float a;                  // Half length of major axis
   float b;                  // Half length of minor axis
   float k1_;

--- a/valhalla/midgard/linesegment2.h
+++ b/valhalla/midgard/linesegment2.h
@@ -5,14 +5,17 @@
 #include <vector>
 
 #include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/vector2.h>
 
 namespace valhalla {
 namespace midgard {
 
 /**
- * Line segment in 2D
+ * Line segment in 2D. Template class to work with Point2 (Euclidean x,y)
+ * or PointLL (latitude,longitude).
  */
+template <class coord_t>
 class LineSegment2 {
  public:
   /**
@@ -25,21 +28,21 @@ class LineSegment2 {
    * @param   p1    First point of the segment.
    * @param   p2    Second point of the segment.
    */
-  LineSegment2(const Point2& p1, const Point2& p2);
+  LineSegment2(const coord_t& p1, const coord_t& p2);
 
   /**
    * Get the first point of the segment.
    * @return  Returns first point of the segment.
    */
-  Point2 a() const;
+  coord_t a() const;
 
   /**
    * Get the second point of the segment.
    * @return  Returns second point of the segment.
    */
-  Point2 b() const;
+  coord_t b() const;
 
-/**
+  /**
    * Finds the distance squared of a specified point from the line segment
    * and the closest point on the segment to the specified point.
    * @param   p        Test point.
@@ -47,7 +50,7 @@ class LineSegment2 {
    * @return  Returns the distance squared from pt to the closest point on
    *          the segment.
   */
-  float DistanceSquared(const Point2& p, Point2& closest) const;
+  float DistanceSquared(const coord_t& p, coord_t& closest) const;
 
   /**
    * Finds the distance of a specified point from the line segment
@@ -57,7 +60,7 @@ class LineSegment2 {
    * @return  Returns the distance from p to the closest point on
    *          the segment.
   */
-  float Distance(const Point2& p, Point2& closest) const;
+  float Distance(const coord_t& p, coord_t& closest) const;
 
   /**
    * Determines if the current segment intersects the specified segment.
@@ -67,16 +70,17 @@ class LineSegment2 {
    * @param   intersect    (OUT) Intersection point.
    * @return  Returns true if an intersection exists, false if not.
    */
-  bool Intersect(const LineSegment2& segment, Point2& intersect) const;
+  bool Intersect(const LineSegment2<coord_t>& segment,
+                 coord_t& intersect) const;
 
   /**
    * Determines if the line segment intersects specified convex polygon.
    * Based on Cyrus-Beck clipping method.
-   * @param  poly   A counter-clockwise oriented polygon.
+   * @param   poly   A counter-clockwise oriented polygon.
    * @return  Returns true if any part of the segment intersects the polygon,
    *          false if no intersection.
    */
-  bool Intersect(const std::vector<Point2>& poly) const;
+  bool Intersect(const std::vector<coord_t>& poly) const;
 
   /**
    * Clips the line segment to a specified convex polygon.
@@ -86,8 +90,8 @@ class LineSegment2 {
    * @return  Returns true if any part of the segment intersects the polygon,
    *          false if no intersection.
    */
-  bool ClipToPolygon(const std::vector<Point2>& poly,
-                     LineSegment2& clip_segment) const;
+  bool ClipToPolygon(const std::vector<coord_t>& poly,
+                     LineSegment2<coord_t>& clip_segment) const;
 
   /**
    * Tests if a point is to left, right, or on the line segment.
@@ -95,11 +99,11 @@ class LineSegment2 {
    * @return   Returns >0 for point to the left, < 0 for point to the right,
    *           and 0 for a point on the line
    */
-  float IsLeft(const Point2& p) const;
+  float IsLeft(const coord_t& p) const;
 
  private:
-  Point2 a_;
-  Point2 b_;
+  coord_t a_;
+  coord_t b_;
 };
 
 }

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -9,8 +9,8 @@ namespace midgard {
 
 /**
  * Latitude, Longitude point. Derives from Point2 and allows access methods
- * using lat,lng naming. Extends functionality to add heading, distance based
- * on spherical geometry.
+ * using lat,lng naming. Extends functionality to add heading, curvature,
+ * and distance based on spherical geometry.
  */
 class PointLL : public Point2 {
  public:
@@ -37,9 +37,8 @@ class PointLL : public Point2 {
   float lng() const;
 
   /**
-   * Checks for validity of the coordinates
-   * @return  Returns the false if lat or lon coordinates are outside of
-   *          the valid range
+   * Checks for validity of the coordinates.
+   * @return  Returns the false if lat or lon coordinates are set to INVALID.
    */
   bool IsValid() const;
 
@@ -57,10 +56,8 @@ class PointLL : public Point2 {
   float Distance(const PointLL& ll2) const;
 
   /**
-   * Calculates the distance squared between two lat/lng's in meters.
-   * Uses spherical geometry. No benefit when using squared distances
-   * over a spherical earth. May want to use DistanceApproximator for
-   * squared distance approximations.
+   * Approximates the distance squared between two lat,lng points - uses
+   * the DistanceApproximator.
    * @param   ll2   Second lat,lng position to calculate distance to.
    * @return  Returns the distance squared in meters.
    */
@@ -95,12 +92,13 @@ class PointLL : public Point2 {
 
   /**
    * Finds the closest point to the supplied polyline as well as the distance
-   * squared to that point and the index of the segment where the closest point lies.
+   * squared to that point and the index of the segment where the closest
+   * point lies.
    * @param  pts     List of points on the polyline.
-   * @return  tuple of <Closest point along the polyline,
-   *                    Returns the distance squared (meters) of the closest point,
-   *                    Index of the segment of the polyline which contains the closest point
-   *                   >
+   * @return tuple of <Closest point along the polyline,
+   *                   distance squared (meters) of the closest point,
+   *                   Index of the segment of the polyline which contains
+   *                      the closest point >
    */
   std::tuple<PointLL, float, int> ClosestPoint(const std::vector<PointLL>& pts) const;
 

--- a/valhalla/midgard/polyline2.h
+++ b/valhalla/midgard/polyline2.h
@@ -1,18 +1,22 @@
 #ifndef VALHALLA_MIDGARD_POLYLINE2_H_
 #define VALHALLA_MIDGARD_POLYLINE2_H_
 
+#include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/aabb2.h>
 #include <valhalla/midgard/clipper2.h>
 #include <valhalla/midgard/linesegment2.h>
-#include <valhalla/midgard/point2.h>
+
 #include <tuple>
 
 namespace valhalla {
 namespace midgard {
 
 /**
- * 2-D polyline
+ * 2-D polyline. This is a template class that works with Point2
+ * (Euclidean x,y) or PointLL (latitude,longitude).
  */
+template <class coord_t>
 class Polyline2 {
  public:
   Polyline2();
@@ -21,15 +25,13 @@ class Polyline2 {
    * Constructor given a list of points.
    * @param  pts  List of points.
    */
-  Polyline2(std::vector<Point2>& pts);
-
-  // TODO - do we need copy constructor and = operator?
+  Polyline2(std::vector<coord_t>& pts);
 
   /**
    * Gets the list of points.
    * @return  Returns the list of points.
    */
-  std::vector<Point2>& pts();
+  std::vector<coord_t>& pts();
 
   /**
    * Add a point to the polyline. Checks to see if the input point is
@@ -37,7 +39,7 @@ class Polyline2 {
    * point if it is equal.
    * @param  p  Point to add to the polyline.
    */
-  void Add(const Point2& p);
+  void Add(const coord_t& p);
 
   /**
    * Finds the length of the polyline by accumulating the length of all
@@ -48,21 +50,22 @@ class Polyline2 {
 
   /**
    * Compute the length of the specified polyline.
-   * @param  pts  Polyline vertices.
+   * @param   pts  Polyline vertices.
    * @return  Returns the length of the polyline.
    */
-  float Length(const std::vector<Point2>& pts) const;
+  float Length(const std::vector<coord_t>& pts) const;
 
   /**
    * Finds the closest point to the supplied polyline as well as the distance
-   * squared to that point and the index of the segment where the closest point lies.
-   * @param  pts     List of points on the polyline.
+   * squared to that point and the index of the segment where the closest
+   * point lies.
+   * @param   pts     List of points on the polyline.
    * @return  tuple of <Closest point along the polyline,
-   *                    Returns the distance squared (meters) of the closest point,
-   *                    Index of the segment of the polyline which contains the closest point
-   *                   >
+   *                    Distance squared (meters) of the closest point,
+   *                    Index of the segment of the polyline which contains
+   *                      the closest point >
    */
-  std::tuple<Point2, float, int> ClosestPoint(const Point2& pt) const;
+  std::tuple<coord_t, float, int> ClosestPoint(const coord_t& pt) const;
 
   /**
    * Generalize this polyline.
@@ -84,23 +87,31 @@ class Polyline2 {
    * @param box  Bounding box to clip this polyline to.
    * @return  Returns the number of vertices in hte clipped polygon.
    */
-  uint32_t Clip(const AABB2& box);
+  uint32_t Clip(const AABB2<coord_t>& box);
 
   /**
    * Gets a polyline clipped to the supplied bounding box. This polyline
    * remains unchanged.
    * @param  box  AABB (rectangle) to which the polyline is clipped.
    */
-  Polyline2 ClippedPolyline(const AABB2& box);
-
-  // TODO - add Google polyline encoding
+  Polyline2 ClippedPolyline(const AABB2<coord_t>& box);
 
 protected:
   // Polyline points
-  std::vector<Point2> pts_;
+  std::vector<coord_t> pts_;
 
+  /**
+   * Douglass-Peucker generalization. Finds the vertex farthest from the
+   * segment between vertices i and j and checks if this distance exceeds
+   * the tolerance. If the distance is less than the tolerance the segment
+   * i,j is added to the output list of generalized vertices.
+   * @param  i  Index of the first vertex.
+   * @param  j  Index of the second vertex.
+   * @param  t2 Tolerance (squared)
+   * @param  genpts List of generalized vertices.
+   */
   void DouglasPeucker(const uint32_t i, const uint32_t j,
-                      const float t2, std::vector<Point2>& genpts);
+                      const float t2, std::vector<coord_t>& genpts);
 };
 
 }

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -15,15 +15,18 @@ namespace midgard {
 
 /**
  * A class that provides a uniform (square) tiling system for a specified
- * bounding box (either in x,y or lat,lng) and tile size.
+ * bounding box and tile size. This is a template class that works with
+ * Point2 (Euclidean x,y) or PointLL (latitude,longitude).
  * A unique tile Id is assigned for each tile based on the following rules:
  *    Tile numbers start at 0 at the min y, x (lower left)
  *    Tile numbers increase by column (x,longitude) then by row (y,latitude)
  *    Tile numbers increase along each row by increasing x,longitude.
  * Contains methods for converting x,y or lat,lng into tile Id and
  * vice-versa.  Methods for relative tiles (using row and column offsets).
- * are also provided.
+ * are also provided. Also includes a method to get a list of tiles covering
+ * a bounding box.
  */
+template <class coord_t>
 class Tiles {
  public:
   /**
@@ -33,7 +36,7 @@ class Tiles {
    * @param   bounds    Bounding box
    * @param   tilesize  Tile size
    */
-  Tiles(const AABB2& bounds, const float tilesize);
+  Tiles(const AABB2<coord_t>& bounds, const float tilesize);
 
   /**
    * Get the tile size.
@@ -54,13 +57,13 @@ class Tiles {
   int32_t ncolumns() const;
 
   /**
-   * Returns the bounding box of the tiling system.
+   * Get the bounding box of the tiling system.
    * @return Bounding box.
    */
-  AABB2 TileBounds() const;
+  AABB2<coord_t> TileBounds() const;
 
   /**
-   * Gets the "row" based on y.
+   * Get the "row" based on y.
    * @param   y   y coordinate
    * @return  Returns the tile row. Returns -1 if outside the
    *          tile system bounds.
@@ -68,7 +71,7 @@ class Tiles {
   int32_t Row(const float y) const;
 
   /**
-   * Gets the "column" based on x.
+   * Get the "column" based on x.
    * @param   x   x coordinate
    * @return  Returns the tile column. Returns -1 if outside the
    *          tile system bounds.
@@ -76,24 +79,24 @@ class Tiles {
   int32_t Col(const float x) const;
 
   /**
-   * Converts the center of a bounding box to a tile Id.
-   * @param   c   Center point.
-   * @return  Returns the tile Id. If the latitude, longitude is outside
-   *          the extent, an error (-1) is returned.
+   * Convert a coordinate into a tile Id. The point is within the tile.
+   * @param   c   Coordinate / point.
+   * @return  Returns the tile Id. If the coordinate is outside tiling system
+   *          extent, an error (-1) is returned.
    */
-  int32_t TileId(const Point2& c) const;
+  int32_t TileId(const coord_t& c) const;
 
   /**
-   * Converts x,y to a tile Id.
+   * Convert x,y to a tile Id.
    * @param   y   y (or lat)
    * @param   x   x (or lng)
-   * @return  Returns the tile Id. -1 (errors( is returned if the x,y is
-   *          outside the bounding box of the tiles.
+   * @return  Returns the tile Id. -1 (error is returned if the x,y is
+   *          outside the bounding box of the tiling sytem).
    */
   int32_t TileId(const float y, const float x) const;
 
   /**
-   * Gets the tile Id given the row Id and column Id.
+   * Get the tile Id given the row Id and column Id.
    * @param  col  Tile column.
    * @param  row  Tile row.
    * @return  Returns the tile Id.
@@ -108,60 +111,56 @@ class Tiles {
   std::pair<int32_t, int32_t> GetRowColumn(const int32_t tileid) const;
 
   /**
-   * Gets a maximum tileid given a bounds and a tile size
+   * Get a maximum tileid given a bounds and a tile size.
    * @param bound       the region for which to compute the maximum tile id
    * @param tile_size   the size of a tile within the region
    * @return the highest tile number within the region
    */
-  static uint32_t MaxTileId(const AABB2& bounds, const float tile_size);
+  static uint32_t MaxTileId(const AABB2<coord_t>& bounds,
+                            const float tile_size);
 
   /**
    * Get the base x,y of a specified tile.
    * @param   tileid   Tile Id.
    * @return  The base x,y of the specified tile.
    */
-  Point2 Base(const int32_t tileid) const;
+  coord_t Base(const int32_t tileid) const;
 
   /**
-   * Gets the y,x extent of the specified tile.
+   * Get the bounding box of the specified tile.
    * @param   tileid   Tile Id.
    * @return  The latitude, longitude extent of the specified tile.
    */
-  AABB2 TileBounds(const int32_t tileid) const;
+  AABB2<coord_t> TileBounds(const int32_t tileid) const;
 
   /**
-   * Gets the y,x extent of the tile with specified row, column.
+   * Get the bounding box of the tile with specified row, column.
    * @param   col   Tile column.
    * @param   row   Tile row.
    * @return  The latitude, longitude extent of the specified tile.
    */
-  AABB2 TileBounds(const int32_t col, const int32_t row) const;
+  AABB2<coord_t> TileBounds(const int32_t col, const int32_t row) const;
 
   /**
-   * Get the tile area in square kilometers.
-   * @return  Returns the tile area in kilometers squared.
-   */
-  float Area(const int32_t tileid) const;
-
-  /**
-   * Gets the center of the specified tile.
+   * Get the center of the specified tile.
    * @param   tileid   Tile Id.
    * @return  The center x,y of the specified tile.
    */
-  Point2 Center(const int32_t tileid) const;
+  coord_t Center(const int32_t tileid) const;
 
   /**
-   * Returns the new tile given a previous tile and a row, column offset.
+   * Get the tile Id given a previous tile and a row, column offset.
    * @param   initial_tile      Id of the tile to offset from.
    * @param   delta_rows    Number of rows to offset (can be negative).
    * @param   delta_cols    Number of columns to offset (can be negative).
    * @return  Tile Id of the new tile.
    */
-  int32_t GetRelativeTileId(const int32_t initial_tile, const int32_t delta_rows,
-                        const int32_t delta_cols) const;
+  int32_t GetRelativeTileId(const int32_t initial_tile,
+                            const int32_t delta_rows,
+                            const int32_t delta_cols) const;
 
    /**
-    * Returns the tile offsets (row,column) between the previous tile Id and
+    * Get the tile offsets (row,column) between the previous tile Id and
     * a new tileid.  The offsets are returned through arguments (references).
     * Offsets can be positive or negative or 0.
     * @param   initial_tileid     Original tile.
@@ -173,27 +172,27 @@ class Tiles {
                        int32_t& delta_rows, int32_t& delta_cols) const;
 
   /**
-   * Get the number of tiles in the extent.
+   * Get the number of tiles in the tiling system.
    * @return  Number of tiles.
    */
   uint32_t TileCount() const;
 
   /**
-   * Gets the neighboring tileid to the right/east.
+   * Get the neighboring tileid to the right/east.
    * @param  tileid   Tile Id.
    * @return  Returns the tile Id of the tile to the right/east.
    */
   int32_t RightNeighbor(const int32_t tileid) const;
 
   /**
-   * Gets the neighboring tileid - west.
+   * Get the neighboring tileid to the left/west.
    * @param  tileid   Tile Id.
    * @return  Returns the tile Id of the tile to the left/west.
    */
   int32_t LeftNeighbor(const int32_t tileid) const;
 
   /**
-   * Gets the neighboring tileid - north.
+   * Get the neighboring tileid above or north.
    * @param  tileid   Tile Id.
    * @return  Returns the tile Id of the tile to the north. Return tileid
    *          if tile Id is on the top row (no neighbor to the north).
@@ -201,7 +200,7 @@ class Tiles {
   int32_t TopNeighbor(const int32_t tileid) const;
 
   /**
-   * Gets the neighboring tileid - south.
+   * Get the neighboring tileid below or south.
    * @param  tileid   Tile Id.
    * @return  Returns the tile Id of the tile to the south. Return tileid
    *          if tile Id is on the bottom row (no neighbor to the south).
@@ -217,14 +216,14 @@ class Tiles {
   bool AreNeighbors(const uint32_t id1, const uint32_t id2) const;
 
   /**
-   * Gets the list of tiles that lie within the specified bounding box.
+   * Get the list of tiles that lie within the specified bounding box.
    * The method finds the center tile and spirals out by finding neighbors
    * and recursively checking if tile is inside and checking/adding
    * neighboring tiles
    * @param  boundingbox  Bounding box
    * @param  maxTiles  Maximum number of tiles to find.
    */
-  const std::vector<int32_t>& TileList(const AABB2& boundingbox);
+  const std::vector<int32_t>& TileList(const AABB2<coord_t>& boundingbox);
 
   /**
    * Color a "connectivity map" starting with a sparse map of uncolored tiles.
@@ -237,7 +236,7 @@ class Tiles {
 
  protected:
   // Bounding box of the tiling system.
-  AABB2 tilebounds_;
+  AABB2<coord_t> tilebounds_;
 
   // Tile size.  Tiles are square (equal y and x size).
   float tilesize_;
@@ -248,16 +247,8 @@ class Tiles {
   // Number of longitude (x or longitude).
   int32_t ncolumns_;
 
-  // Tile list being constructed
+  // Tile list - populated by the TileList method.
   std::vector<int32_t> tilelist_;
-
-  // List of tiles to check if in view. Use a list: push new entries on the
-  // back and pop off the front. The tile search tends to spiral out from
-  // the center.
-  std::list<int32_t> checklist_;
-
-  // Visited tiles
-  std::unordered_set<int32_t> visitedtiles_;
 };
 
 }


### PR DESCRIPTION
Template classes use Point2 or PointLL. DIffer mostly in distance computations.
Remove a couple methods (like tile Area) that do not have consistency between coordinate types. 