### PR TITLE
more accurate resampling

### DIFF
--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -71,16 +71,6 @@ float PointLL::Distance(const PointLL& ll2) const {
     return (float)(acos(cosb) * kRadEarthMeters);
 }
 
-// Compute the length of the polyline represented by a set of lat,lng points.
-// Avoids having to copy the points into a polyline.
-float PointLL::Length(const std::vector<PointLL>& pts) {
-  float length = 0.0f;
-  for (auto pt1 = pts.begin(), pt2 = pt1 + 1; pt2 < pts.end(); pt1++, pt2++) {
-    length+= pt1->Distance(*pt2);
-  }
-  return length;
-}
-
 // Calculates the curvature using this position and 2 others. Found by
 // computing the radius of the circle that circumscribes the 3 positions.
 float PointLL::Curvature(const PointLL& ll1, const PointLL& ll2) const {

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -7,14 +7,20 @@
 #include <cmath>
 #include <stdlib.h>
 #include <sstream>
-#include <vector>
 #include <fstream>
 #include <algorithm>
+#include <vector>
+#include <list>
 #include <sys/stat.h>
 
 namespace {
+
 constexpr double POLYLINE_PRECISION = 1E6;
 constexpr double INV_POLYLINE_PRECISION = 1.0 / POLYLINE_PRECISION;
+constexpr double RAD_PER_METER  = 1.0 / 6378160.187;
+constexpr double RAD_PER_DEG = M_PI / 180.0;
+constexpr double DEG_PER_RAD = 180.0 / M_PI;
+
 }
 
 namespace valhalla {
@@ -27,14 +33,6 @@ int GetTime(const float length, const float speed) {
 uint32_t GetTurnDegree(const uint32_t from_heading, const uint32_t to_heading) {
   return (((to_heading - from_heading) + 360) % 360);
 }
-
-// TODO - do we really need these?
-/*float degrees_to_radians(const float d) {
- return d * kDegPerRad;
- }
- float radians_to_degrees(const float r) {
- return r * kRadPerDeg;
- }*/
 
 float rand01() {
   return (float)rand() / (float)RAND_MAX;
@@ -90,13 +88,7 @@ std::string encode(const container_t& points) {
 }
 
 template<class container_t>
-container_t decode(const std::string& encoded) {
-  //a place to keep the output
-  container_t output;
-  //based on the length of the string we can make a guess at how many points are in it
-  //as above we'll say each point uses 6 bytes, so we overshoot to a quarter of the size
-  output.reserve(encoded.size() * .25f);
-
+void decode(const std::string& encoded, container_t& output) {
   //what byte are we looking at
   size_t i = 0;
 
@@ -128,23 +120,35 @@ container_t decode(const std::string& encoded) {
     last_lon = lon;
     last_lat = lat;
   }
-  return output;
+}
+
+//specialize for list
+template <>
+std::list<PointLL> decode<std::list<PointLL> >(const std::string& encoded) {
+  //a place to keep the output
+  std::list<PointLL> l;
+  decode(encoded, l);
+  return l;
+}
+
+//specialize for vector
+template <>
+std::vector<PointLL> decode<std::vector<PointLL> >(const std::string& encoded) {
+  //a place to keep the output
+  std::vector<PointLL> v;
+  //based on the length of the string we can make a guess at how many points are in it
+  //as above we'll say each point uses 6 bytes, so we overshoot to a quarter of the size
+  v.reserve(encoded.size() * .25f);
+  decode(encoded, v);
+  return v;
 }
 
 //explicit instantiations, we should probably just move the implementation to the header so that
 //projects that depend on this library aren't limited in the instantiations made here
 template std::string encode<std::vector<PointLL> >(const std::vector<PointLL>&);
-template std::string encode<std::vector<Point2> >(const std::vector<Point2>&);
-template std::string encode<std::vector<std::pair<float, float> > >(
-    const std::vector<std::pair<float, float> >&);
-template std::string encode<std::vector<std::pair<double, double> > >(
-    const std::vector<std::pair<double, double> >&);
+template std::string encode<std::list<PointLL> >(const std::list<PointLL>&);
 template std::vector<PointLL> decode<std::vector<PointLL> >(const std::string&);
-template std::vector<Point2> decode<std::vector<Point2> >(const std::string&);
-template std::vector<std::pair<float, float> > decode<
-    std::vector<std::pair<float, float> > >(const std::string&);
-template std::vector<std::pair<double, double> > decode<
-    std::vector<std::pair<double, double> > >(const std::string&);
+template std::list<PointLL> decode<std::list<PointLL> >(const std::string&);
 
 memory_status::memory_status(const std::unordered_set<std::string> interest){
   //grab the vm stats from the file
@@ -188,59 +192,67 @@ std::ostream& operator<<(std::ostream& stream, const memory_status& s){
   return stream;
 }
 
-
-//TODO: this assumes that there is a linear relationship between distance on the sphere and
-//spherical coordinates, which is not the case for the x coordinate. this wont matter for small
-//distances...
-std::vector<PointLL> resample_spherical_polyline(const std::vector<PointLL>& polyline, float resolution) {
+/* This method makes use of several computations explained and demonstrated at:
+ * http://williams.best.vwh.net/avform.htm *
+ * We humbly bow to you sir!
+ */
+template <class container_t>
+container_t resample_spherical_polyline(const container_t& polyline, double resolution) {
   //start out with the first point
-  std::vector<PointLL> resampled;
+  container_t resampled;
   if(polyline.size() == 0)
     return resampled;
-  resampled.reserve(polyline.size());
-  resampled.push_back(polyline.front());
+  resampled.emplace_back(polyline.front());
 
   //for each point
-  float remaining_dist = 0;
-  auto last = resampled.back();
-  for(auto p = polyline.cbegin() + 1; p != polyline.cend(); ++p) {
-    //get the appx distance of this segment
-    auto dist = DistanceApproximator::DistanceSquared(*p, *(p - 1));
-    dist = 1.f / FastInvSqrt(dist);
-    auto ratio = resolution / dist;
-    auto x_off = ratio * (p->first - (p - 1)->first);
-    auto y_off = ratio * (p->second - (p - 1)->second);
-
-    //if there was some left from the previous segment
-    if(remaining_dist > 0) {
-      //we can fit a point on this segment
-      if(remaining_dist < dist) {
-        auto remaining_ratio = remaining_dist / resolution;
-        resampled.emplace_back(last.first + x_off * remaining_ratio, last.second + y_off * remaining_ratio);
-        last = resampled.back();
-        dist -= remaining_dist;
-      }//we are swallowing this segment as well
-      else {
-        last = *p;
-        remaining_dist -= dist;
-        continue;
-      }
+  resolution *= RAD_PER_METER;
+  double remaining = resolution;
+  for(auto p = std::next(polyline.cbegin()); p != polyline.cend(); ++p) {
+    //radians
+    double lon2 = p->first * -RAD_PER_DEG;
+    double lat2 = p->second * RAD_PER_DEG;
+    //how much do we have left on this segment from where we are (in great arc radians)
+    //double d = 2.0 * asin(sqrt(pow(sin((resampled.back().second * RAD_PER_DEG - lat2) / 2.0), 2.0) + cos(resampled.back().second * RAD_PER_DEG) * cos(lat2) *pow(sin((resampled.back().first * -RAD_PER_DEG - lon2) / 2.0), 2.0)));
+    double d = acos(
+      sin(resampled.back().second * RAD_PER_DEG) * sin(lat2) +
+      cos(resampled.back().second * RAD_PER_DEG) * cos(lat2) *
+      cos(resampled.back().first * -RAD_PER_DEG - lon2)
+    );
+    //keep placing points while we can fit them
+    while(d > remaining) {
+      //some precomputed stuff
+      double lon1 = resampled.back().first * -RAD_PER_DEG;
+      double lat1 = resampled.back().second * RAD_PER_DEG;
+      auto sd = sin(d);
+      auto a = sin(d - remaining) / sd;
+      auto acs1 = a * cos(lat1);
+      auto b = sin(remaining) / sd;
+      auto bcs2 = b * cos(lat2);
+      //find the interpolated point along the arc
+      auto x = acs1 * cos(lon1) + bcs2 * cos(lon2);
+      auto y = acs1 * sin(lon1) + bcs2 * sin(lon2);
+      auto z = a * sin(lat1) + b * sin(lat2);
+      auto lon = atan2(y, x) * -DEG_PER_RAD;
+      auto lat = atan2(z, sqrt(x * x + y * y)) * DEG_PER_RAD;
+      resampled.emplace_back(lon, lat);
+      //we just consumed a bit
+      d -= remaining;
+      //we need another bit
+      remaining = resolution;
     }
-
-    //while we can place a point on this segment
-    while(dist > resolution) {
-      //from the last point we got up to p is whats left so move next_distance along it
-      resampled.emplace_back(last.first + x_off, last.second + y_off);
-      last = resampled.back();
-      dist -= resolution;
-    }
-    //we are up to p on the polyline now
-    last = *p;
-    remaining_dist = resolution - dist;
+    //we're going to the next point so consume whatever's left
+    remaining -= d;
   }
 
+  //TODO: do we want to let them know remaining?
+
+  //hand it back
   return resampled;
 }
+
+//explicit instantiations
+template std::vector<PointLL> resample_spherical_polyline<std::vector<PointLL> >(const std::vector<PointLL>&, double);
+template std::list<PointLL> resample_spherical_polyline<std::list<PointLL> >(const std::list<PointLL>&, double);
 
 }
 }

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -125,36 +125,56 @@ void decode(const std::string& encoded, container_t& output) {
 //specialize for list
 template <>
 std::list<PointLL> decode<std::list<PointLL> >(const std::string& encoded) {
-  //a place to keep the output
   std::list<PointLL> l;
   decode(encoded, l);
   return l;
 }
 template <>
 std::list<std::pair<double,double> > decode<std::list<std::pair<double,double> > >(const std::string& encoded) {
-  //a place to keep the output
   std::list<std::pair<double,double> > l;
   decode(encoded, l);
   return l;
 }
+template <>
+std::list<Point2> decode<std::list<Point2> >(const std::string& encoded) {
+  std::list<Point2> l;
+  decode(encoded, l);
+  return l;
+}
+template <>
+std::list<std::pair<float,float> > decode<std::list<std::pair<float,float> > >(const std::string& encoded) {
+  std::list<std::pair<float,float> > l;
+  decode(encoded, l);
+  return l;
+}
 
-//specialize for vector
+//specialize for vector with a preallocation
+//based on the length of the string we can make a guess at how many points are in it
+//as above we'll say each point uses 6 bytes, so we overshoot to a quarter of the size
 template <>
 std::vector<PointLL> decode<std::vector<PointLL> >(const std::string& encoded) {
-  //a place to keep the output
   std::vector<PointLL> v;
-  //based on the length of the string we can make a guess at how many points are in it
-  //as above we'll say each point uses 6 bytes, so we overshoot to a quarter of the size
   v.reserve(encoded.size() * .25f);
   decode(encoded, v);
   return v;
 }
 template <>
 std::vector<std::pair<double,double> > decode<std::vector<std::pair<double,double> > >(const std::string& encoded) {
-  //a place to keep the output
   std::vector<std::pair<double,double> > v;
-  //based on the length of the string we can make a guess at how many points are in it
-  //as above we'll say each point uses 6 bytes, so we overshoot to a quarter of the size
+  v.reserve(encoded.size() * .25f);
+  decode(encoded, v);
+  return v;
+}
+template <>
+std::vector<Point2> decode<std::vector<Point2> >(const std::string& encoded) {
+  std::vector<Point2> v;
+  v.reserve(encoded.size() * .25f);
+  decode(encoded, v);
+  return v;
+}
+template <>
+std::vector<std::pair<float,float> > decode<std::vector<std::pair<float,float> > >(const std::string& encoded) {
+  std::vector<std::pair<float,float> > v;
   v.reserve(encoded.size() * .25f);
   decode(encoded, v);
   return v;
@@ -164,12 +184,23 @@ std::vector<std::pair<double,double> > decode<std::vector<std::pair<double,doubl
 //projects that depend on this library aren't limited in the instantiations made here
 template std::string encode<std::vector<PointLL> >(const std::vector<PointLL>&);
 template std::string encode<std::vector<std::pair<double,double> > >(const std::vector<std::pair<double,double> >&);
+template std::string encode<std::vector<Point2> >(const std::vector<Point2>&);
+template std::string encode<std::vector<std::pair<float,float> > >(const std::vector<std::pair<float,float> >&);
+
 template std::string encode<std::list<PointLL> >(const std::list<PointLL>&);
 template std::string encode<std::list<std::pair<double,double> > >(const std::list<std::pair<double,double> >&);
+template std::string encode<std::list<Point2> >(const std::list<Point2>&);
+template std::string encode<std::list<std::pair<float,float> > >(const std::list<std::pair<float,float> >&);
+
 template std::vector<PointLL> decode<std::vector<PointLL> >(const std::string&);
 template std::vector<std::pair<double,double> > decode<std::vector<std::pair<double,double> > >(const std::string&);
+template std::vector<Point2> decode<std::vector<Point2> >(const std::string&);
+template std::vector<std::pair<float,float> > decode<std::vector<std::pair<float,float> > >(const std::string&);
+
 template std::list<PointLL> decode<std::list<PointLL> >(const std::string&);
 template std::list<std::pair<double,double> > decode<std::list<std::pair<double,double> > >(const std::string&);
+template std::list<Point2> decode<std::list<Point2> >(const std::string&);
+template std::list<std::pair<float,float> > decode<std::list<std::pair<float,float> > >(const std::string&);
 
 memory_status::memory_status(const std::unordered_set<std::string> interest){
   //grab the vm stats from the file

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -9,15 +9,13 @@ using namespace valhalla::midgard;
 
 namespace {
 
-using container_t = std::vector<PointLL >;
+using container_t = std::vector<std::pair<double,double> >;
 
 bool appx_equal(const container_t& a, const container_t& b) {
   if(a.size() != b.size())
     return false;
   for(size_t i = 0; i < a.size(); ++i) {
-    const PointLL& x = static_cast<const PointLL&>(a[i]);
-    const PointLL& y = static_cast<const PointLL&>(b[i]);
-    if(!x.ApproximatelyEqual(y))
+    if(!equal(a[i].first, b[i].first) || !equal(a[i].second, b[i].second))
       return false;
   }
   return true;
@@ -58,11 +56,10 @@ void TestSimple() {
    * python -c "import random; import gpolyencode; x = [ [round(random.random() * 180 - 90, 5), round(random.random() * 360 - 180, 5)] for a in range(0, random.randint(1,100)) ]; p = gpolyencode.GPolyEncoder().encode(x)['points']; print; print 'do_pair(' + str(x).replace('[','{').replace(']','}') + ', \"' + repr(p)[1:-1] + '\");'; print"
    */
 
-  //check an easy case first just to be sure Point2/PointLL is working
-  auto encoded = encode<container_t>({{-76.3002f, 40.0433f}, {-76.3036f, 40.043f}});
-  if(encoded != "gq`kkAny~opCvQnsE") {
-    throw std::runtime_error("Encoding of Point2/PointLL vector failed");
-  }
+  //check an easy case first just to be sure its working
+  auto encoded = encode<container_t>({{-76.3002, 40.0433}, {-76.3036, 40.043}});
+  if(encoded != "gq`kkAny~opCvQnsE")
+    throw std::runtime_error("Expected: gq`kkAny~opCvQnsE but got: " + encoded);
 
   //note we are testing with higher precision to avoid truncation/roundoff errors just to make the test cases easier to generate
   do_pair({{41.37084, -5.03016}, {76.8342, 42.01251}}, "~o_rHola|mA{egvxA_kosbA");

--- a/test/encode.cc
+++ b/test/encode.cc
@@ -9,15 +9,14 @@ using namespace valhalla::midgard;
 
 namespace {
 
-using perc_t = double;
-using container_t = std::vector<std::pair<perc_t, perc_t> >;
+using container_t = std::vector<PointLL >;
 
 bool appx_equal(const container_t& a, const container_t& b) {
   if(a.size() != b.size())
     return false;
   for(size_t i = 0; i < a.size(); ++i) {
-    const Point2& x = static_cast<const Point2&>(a[i]);
-    const Point2& y = static_cast<const Point2&>(b[i]);
+    const PointLL& x = static_cast<const PointLL&>(a[i]);
+    const PointLL& y = static_cast<const PointLL&>(b[i]);
     if(!x.ApproximatelyEqual(y))
       return false;
   }
@@ -60,7 +59,7 @@ void TestSimple() {
    */
 
   //check an easy case first just to be sure Point2/PointLL is working
-  auto encoded = encode<container_t>({{-76.3002, 40.0433}, {-76.3036, 40.043}});
+  auto encoded = encode<container_t>({{-76.3002f, 40.0433f}, {-76.3036f, 40.043f}});
   if(encoded != "gq`kkAny~opCvQnsE") {
     throw std::runtime_error("Encoding of Point2/PointLL vector failed");
   }

--- a/test/util.cc
+++ b/test/util.cc
@@ -4,7 +4,6 @@
 #include "midgard/constants.h"
 
 #include <list>
-#include <iostream>
 
 using namespace valhalla::midgard;
 
@@ -115,25 +114,13 @@ void TestClamp() {
 void TestResample() {
   for(const auto& example :
     std::vector<std::pair<float, std::string> > {
-      { 160.f, "cfcglAlj_~pCsiAdOaeAvN}_@|ImTyBiW}I}TsQ}d@}^cUyWcGaHoNcPc`@oh@ykAw`BuTeZkt@emAquAk}BucAelBwXqg@o|@{~@oSiBuOkAiCtDw`AxMaHxBmUpGcFzAe_Atm@_w@ju@wb@hWu_@~Ied@}@wb@uO}_@uDmTrFwb@~g@wNfw@jGrxBiClJy\\yBsvC_hAwN|@wNl^qBvYiH`fAjGxwGn|@vpFiC|eD?z@cK|pCcAhWsGjj@qQju@iWtOwXrF}s@?m}Agw@g`BmhAycC{rB}gAgw@ceAiw@_|AofAcPyByHsQy[kUgh@qHyvDjV_cApGa{@vm@iWfYuD?{AhLwXn^m@hL_I|@slClcEwb@fNalAoH{mA}^kdBk`Aso@iLm^z@cBzAsK|JvD~|@vXv`Am@rQwDpHso@e[_xDu~Cy}GqvEoT{Ked@oHen@z@gTzKwX|^egBnbEuh@dmAwdCdrF_eC~uF"},
-      //{ 60.f, "etgflAbin|pCjFxWvNls@vMhl@xM~]|JtYzEb\\dF~Rp\\ngAzObo@jQnh@xMfYfIlJvHxWtJb[tJvWjLxWlExMpVvl@hRbe@hRhb@zKp\\bGtYtJhMfNdPfI`RvHtOhN~SvHbQvMhV|Pnh@bPxWnTxWfMzUdKpR`CpGTpGcAbGqBfD_^l_@{PbPeFbRuJdYkPlJwNjAgIbGsApH~Cx`@dFdPbFjKt@nJ?lJyGfCcGiBuJkAoCfCOrGrFzU|DvCdFdFbAvCoC|IsFvDoJrFmYdPqBnHLrGdA~HpGnHfNnJpRvCvStOlTbQhM|TtEhMdOx`@jLlUdK~HlNvCxM|@vNpGdJMln@un@`XqRvRoSlPuOpGwCrFdDlU|_@cBtOaGzUaSre@aRfX}T~]mUz`@sZfc@cGtD_XtZ`BvCh\\_S|ErFxQjU`DvO`BrF{@zJyCbGd@xBpCiBnDaIpBeEvCzApCpH`BzJe@rQmEfYeEfCwDxMqB~R}D`SeEnHoDvCwDvDaBjK_@|JrBnIlDjAdFrFtDlJNbG\\lJbBrPt^vw@`]tx@`BnJtFfMtDhClEzUfDbQNtOeAlKaBpG_@lJqB~HMxMsFbFaD`HqB~HjAvDd@nIgCtEsFfCqHl@cFiBgEwDoCiCqB^qCxByLhWcGnIsAhMuD`HePdY}JjLsF|IuNfOyHbFeJ{AuJzAcGpG]nJu@`GqBj`@aC`I?xLtE`HvHbQrGdOfIxMvI~RrFjV|DtEhGdEpCLdOnIxCrGlDdc@NzK}DhMeAlJ^tF~BrEbB`Id@~HcAzKaCpGcGhWiGnTyMjUuI`HcLnIuJbGyMfCgS|@oCm@mF{AyG{AkFjAeEzBiCrFwCjAkB_@aGeOe@yBsA{@sA{AsA{AsBkAs@z@oDgCeK}@iBiB{@kAmAcGe@]aB}@yB{@kB?uIyCyCm@gIkAiBMe@L}@?aBMcBLiB?u@NwD?UkA{A{AsA}@m@wCkAiBkA{AsA{AqB{@yB_@yB|@iC?yBzAyBrF{@zAmAjAk@hBsBNqLpGsFjByBz@iCiBoC?qMLej@{J{y@rF_DxAgSfEcp@fN}EjAcVz@sExByBhCgIlJcB|@cBLoCdF{Al@aBz@g@xB{@\\cB^{@vCGhB\\zAFfDGxBe@l@aCjAFhC{AjAgChBu@NcBhBqB]qBl@qBjAqBjA}@|@aCzA{AhB_C\\aC^sBxAyBl@yAjBcBxA{AzA_D|@u@xBcAhB{AxBqBzAyBhBaCzAyBzAgChByBjAyBjB{BzA_Cz@yBzAiCzAyBzAyBxAqBjAkBzAyBjAiBjAcBlAaBjAkBjAiBzAkBjAqBzAiBjAu@z@cBjAiBzAyBjBcBxAiB|@aCNyB\\iC\\gCl@yBNaC?iC?gCLoDNqBLsB^aBjAkBhByB|@qBjA{@l@kBz@yBlAyBjA_DxByBjAxBvC?zAmJ}@iCbGFfDaMxMcFtD"},
+      { 100.f, "cfcglAlj_~pCsiAdOaeAvN}_@|ImTyBiW}I}TsQ}d@}^cUyWcGaHoNcPc`@oh@ykAw`BuTeZkt@emAquAk}BucAelBwXqg@o|@{~@oSiBuOkAiCtDw`AxMaHxBmUpGcFzAe_Atm@_w@ju@wb@hWu_@~Ied@}@wb@uO}_@uDmTrFwb@~g@wNfw@jGrxBiClJy\\yBsvC_hAwN|@wNl^qBvYiH`fAjGxwGn|@vpFiC|eD?z@cK|pCcAhWsGjj@qQju@iWtOwXrF}s@?m}Agw@g`BmhAycC{rB}gAgw@ceAiw@_|AofAcPyByHsQy[kUgh@qHyvDjV_cApGa{@vm@iWfYuD?{AhLwXn^m@hL_I|@slClcEwb@fNalAoH{mA}^kdBk`Aso@iLm^z@cBzAsK|JvD~|@vXv`Am@rQwDpHso@e[_xDu~Cy}GqvEoT{Ked@oHen@z@gTzKwX|^egBnbEuh@dmAwdCdrF_eC~uF"},
+      { 60.f, "etgflAbin|pCjFxWvNls@vMhl@xM~]|JtYzEb\\dF~Rp\\ngAzObo@jQnh@xMfYfIlJvHxWtJb[tJvWjLxWlExMpVvl@hRbe@hRhb@zKp\\bGtYtJhMfNdPfI`RvHtOhN~SvHbQvMhV|Pnh@bPxWnTxWfMzUdKpR`CpGTpGcAbGqBfD_^l_@{PbPeFbRuJdYkPlJwNjAgIbGsApH~Cx`@dFdPbFjKt@nJ?lJyGfCcGiBuJkAoCfCOrGrFzU|DvCdFdFbAvCoC|IsFvDoJrFmYdPqBnHLrGdA~HpGnHfNnJpRvCvStOlTbQhM|TtEhMdOx`@jLlUdK~HlNvCxM|@vNpGdJMln@un@`XqRvRoSlPuOpGwCrFdDlU|_@cBtOaGzUaSre@aRfX}T~]mUz`@sZfc@cGtD_XtZ`BvCh\\_S|ErFxQjU`DvO`BrF{@zJyCbGd@xBpCiBnDaIpBeEvCzApCpH`BzJe@rQmEfYeEfCwDxMqB~R}D`SeEnHoDvCwDvDaBjK_@|JrBnIlDjAdFrFtDlJNbG\\lJbBrPt^vw@`]tx@`BnJtFfMtDhClEzUfDbQNtOeAlKaBpG_@lJqB~HMxMsFbFaD`HqB~HjAvDd@nIgCtEsFfCqHl@cFiBgEwDoCiCqB^qCxByLhWcGnIsAhMuD`HePdY}JjLsF|IuNfOyHbFeJ{AuJzAcGpG]nJu@`GqBj`@aC`I?xLtE`HvHbQrGdOfIxMvI~RrFjV|DtEhGdEpCLdOnIxCrGlDdc@NzK}DhMeAlJ^tF~BrEbB`Id@~HcAzKaCpGcGhWiGnTyMjUuI`HcLnIuJbGyMfCgS|@oCm@mF{AyG{AkFjAeEzBiCrFwCjAkB_@aGeOe@yBsA{@sA{AsA{AsBkAs@z@oDgCeK}@iBiB{@kAmAcGe@]aB}@yB{@kB?uIyCyCm@gIkAiBMe@L}@?aBMcBLiB?u@NwD?UkA{A{AsA}@m@wCkAiBkA{AsA{AqB{@yB_@yB|@iC?yBzAyBrF{@zAmAjAk@hBsBNqLpGsFjByBz@iCiBoC?qMLej@{J{y@rF_DxAgSfEcp@fN}EjAcVz@sExByBhCgIlJcB|@cBLoCdF{Al@aBz@g@xB{@\\cB^{@vCGhB\\zAFfDGxBe@l@aCjAFhC{AjAgChBu@NcBhBqB]qBl@qBjAqBjA}@|@aCzA{AhB_C\\aC^sBxAyBl@yAjBcBxA{AzA_D|@u@xBcAhB{AxBqBzAyBhBaCzAyBzAgChByBjAyBjB{BzA_Cz@yBzAiCzAyBzAyBxAqBjAkBzAyBjAiBjAcBlAaBjAkBjAiBzAkBjAqBzAiBjAu@z@cBjAiBzAyBjBcBxAiB|@aCNyB\\iC\\gCl@yBNaC?iC?gCLoDNqBLsB^aBjAkBhByB|@qBjA{@l@kBz@yBlAyBjA_DxByBjAxBvC?zAmJ}@iCbGFfDaMxMcFtD"},
     }) {
 
     //try it
     auto input_shape = decode<std::vector<PointLL>>(example.second);
-    input_shape = {{9.284638166427612,47.271290961003956},{9.284638166427612,47.27015165787987},{9.283994436264038,47.269503736537516}};
     auto resampled = resample_spherical_polyline(input_shape, example.first);
-
-
-
-    std::cout << std::endl << "input" << std::endl;
-    for(auto p : input_shape){
-      std::cout << '[' << p.first << ',' << p.second << "],";
-    }
-    std::cout << std::endl << "output" << std::endl;
-    for(auto p : resampled){
-      std::cout << '[' << p.first << ',' << p.second << "],";
-    }
 
     //check that nothing is too far apart
     for(auto p = std::next(resampled.cbegin()); p != resampled.cend(); ++p) {

--- a/test/util.cc
+++ b/test/util.cc
@@ -113,21 +113,18 @@ void TestClamp() {
 
 
 void TestResample() {
-  for(const auto example :
-    std::vector<std::pair<std::string, float>> {
-      {
-        "cfcglAlj_~pCsiAdOaeAvN}_@|ImTyBiW}I}TsQ}d@}^cUyWcGaHoNcPc`@oh@ykAw`BuTeZkt@emAquAk}BucAelBwXqg@o|@{~@oSiBuOkAiCtDw`AxMaHxBmUpGcFzAe_Atm@_w@ju@wb@hWu_@~Ied@}@wb@uO}_@uDmTrFwb@~g@wNfw@jGrxBiClJy\\yBsvC_hAwN|@wNl^qBvYiH`fAjGxwGn|@vpFiC|eD?z@cK|pCcAhWsGjj@qQju@iWtOwXrF}s@?m}Agw@g`BmhAycC{rB}gAgw@ceAiw@_|AofAcPyByHsQy[kUgh@qHyvDjV_cApGa{@vm@iWfYuD?{AhLwXn^m@hL_I|@slClcEwb@fNalAoH{mA}^kdBk`Aso@iLm^z@cBzAsK|JvD~|@vXv`Am@rQwDpHso@e[_xDu~Cy}GqvEoT{Ked@oHen@z@gTzKwX|^egBnbEuh@dmAwdCdrF_eC~uF",
-        100.f
-      },
-      {
-        "etgflAbin|pCjFxWvNls@vMhl@xM~]|JtYzEb\\dF~Rp\\ngAzObo@jQnh@xMfYfIlJvHxWtJb[tJvWjLxWlExMpVvl@hRbe@hRhb@zKp\\bGtYtJhMfNdPfI`RvHtOhN~SvHbQvMhV|Pnh@bPxWnTxWfMzUdKpR`CpGTpGcAbGqBfD_^l_@{PbPeFbRuJdYkPlJwNjAgIbGsApH~Cx`@dFdPbFjKt@nJ?lJyGfCcGiBuJkAoCfCOrGrFzU|DvCdFdFbAvCoC|IsFvDoJrFmYdPqBnHLrGdA~HpGnHfNnJpRvCvStOlTbQhM|TtEhMdOx`@jLlUdK~HlNvCxM|@vNpGdJMln@un@`XqRvRoSlPuOpGwCrFdDlU|_@cBtOaGzUaSre@aRfX}T~]mUz`@sZfc@cGtD_XtZ`BvCh\\_S|ErFxQjU`DvO`BrF{@zJyCbGd@xBpCiBnDaIpBeEvCzApCpH`BzJe@rQmEfYeEfCwDxMqB~R}D`SeEnHoDvCwDvDaBjK_@|JrBnIlDjAdFrFtDlJNbG\\lJbBrPt^vw@`]tx@`BnJtFfMtDhClEzUfDbQNtOeAlKaBpG_@lJqB~HMxMsFbFaD`HqB~HjAvDd@nIgCtEsFfCqHl@cFiBgEwDoCiCqB^qCxByLhWcGnIsAhMuD`HePdY}JjLsF|IuNfOyHbFeJ{AuJzAcGpG]nJu@`GqBj`@aC`I?xLtE`HvHbQrGdOfIxMvI~RrFjV|DtEhGdEpCLdOnIxCrGlDdc@NzK}DhMeAlJ^tF~BrEbB`Id@~HcAzKaCpGcGhWiGnTyMjUuI`HcLnIuJbGyMfCgS|@oCm@mF{AyG{AkFjAeEzBiCrFwCjAkB_@aGeOe@yBsA{@sA{AsA{AsBkAs@z@oDgCeK}@iBiB{@kAmAcGe@]aB}@yB{@kB?uIyCyCm@gIkAiBMe@L}@?aBMcBLiB?u@NwD?UkA{A{AsA}@m@wCkAiBkA{AsA{AqB{@yB_@yB|@iC?yBzAyBrF{@zAmAjAk@hBsBNqLpGsFjByBz@iCiBoC?qMLej@{J{y@rF_DxAgSfEcp@fN}EjAcVz@sExByBhCgIlJcB|@cBLoCdF{Al@aBz@g@xB{@\\cB^{@vCGhB\\zAFfDGxBe@l@aCjAFhC{AjAgChBu@NcBhBqB]qBl@qBjAqBjA}@|@aCzA{AhB_C\\aC^sBxAyBl@yAjBcBxA{AzA_D|@u@xBcAhB{AxBqBzAyBhBaCzAyBzAgChByBjAyBjB{BzA_Cz@yBzAiCzAyBzAyBxAqBjAkBzAyBjAiBjAcBlAaBjAkBjAiBzAkBjAqBzAiBjAu@z@cBjAiBzAyBjBcBxAiB|@aCNyB\\iC\\gCl@yBNaC?iC?gCLoDNqBLsB^aBjAkBhByB|@qBjA{@l@kBz@yBlAyBjA_DxByBjAxBvC?zAmJ}@iCbGFfDaMxMcFtD",
-        60.f
-      }
+  for(const auto& example :
+    std::vector<std::pair<float, std::string> > {
+      { 160.f, "cfcglAlj_~pCsiAdOaeAvN}_@|ImTyBiW}I}TsQ}d@}^cUyWcGaHoNcPc`@oh@ykAw`BuTeZkt@emAquAk}BucAelBwXqg@o|@{~@oSiBuOkAiCtDw`AxMaHxBmUpGcFzAe_Atm@_w@ju@wb@hWu_@~Ied@}@wb@uO}_@uDmTrFwb@~g@wNfw@jGrxBiClJy\\yBsvC_hAwN|@wNl^qBvYiH`fAjGxwGn|@vpFiC|eD?z@cK|pCcAhWsGjj@qQju@iWtOwXrF}s@?m}Agw@g`BmhAycC{rB}gAgw@ceAiw@_|AofAcPyByHsQy[kUgh@qHyvDjV_cApGa{@vm@iWfYuD?{AhLwXn^m@hL_I|@slClcEwb@fNalAoH{mA}^kdBk`Aso@iLm^z@cBzAsK|JvD~|@vXv`Am@rQwDpHso@e[_xDu~Cy}GqvEoT{Ked@oHen@z@gTzKwX|^egBnbEuh@dmAwdCdrF_eC~uF"},
+      //{ 60.f, "etgflAbin|pCjFxWvNls@vMhl@xM~]|JtYzEb\\dF~Rp\\ngAzObo@jQnh@xMfYfIlJvHxWtJb[tJvWjLxWlExMpVvl@hRbe@hRhb@zKp\\bGtYtJhMfNdPfI`RvHtOhN~SvHbQvMhV|Pnh@bPxWnTxWfMzUdKpR`CpGTpGcAbGqBfD_^l_@{PbPeFbRuJdYkPlJwNjAgIbGsApH~Cx`@dFdPbFjKt@nJ?lJyGfCcGiBuJkAoCfCOrGrFzU|DvCdFdFbAvCoC|IsFvDoJrFmYdPqBnHLrGdA~HpGnHfNnJpRvCvStOlTbQhM|TtEhMdOx`@jLlUdK~HlNvCxM|@vNpGdJMln@un@`XqRvRoSlPuOpGwCrFdDlU|_@cBtOaGzUaSre@aRfX}T~]mUz`@sZfc@cGtD_XtZ`BvCh\\_S|ErFxQjU`DvO`BrF{@zJyCbGd@xBpCiBnDaIpBeEvCzApCpH`BzJe@rQmEfYeEfCwDxMqB~R}D`SeEnHoDvCwDvDaBjK_@|JrBnIlDjAdFrFtDlJNbG\\lJbBrPt^vw@`]tx@`BnJtFfMtDhClEzUfDbQNtOeAlKaBpG_@lJqB~HMxMsFbFaD`HqB~HjAvDd@nIgCtEsFfCqHl@cFiBgEwDoCiCqB^qCxByLhWcGnIsAhMuD`HePdY}JjLsF|IuNfOyHbFeJ{AuJzAcGpG]nJu@`GqBj`@aC`I?xLtE`HvHbQrGdOfIxMvI~RrFjV|DtEhGdEpCLdOnIxCrGlDdc@NzK}DhMeAlJ^tF~BrEbB`Id@~HcAzKaCpGcGhWiGnTyMjUuI`HcLnIuJbGyMfCgS|@oCm@mF{AyG{AkFjAeEzBiCrFwCjAkB_@aGeOe@yBsA{@sA{AsA{AsBkAs@z@oDgCeK}@iBiB{@kAmAcGe@]aB}@yB{@kB?uIyCyCm@gIkAiBMe@L}@?aBMcBLiB?u@NwD?UkA{A{AsA}@m@wCkAiBkA{AsA{AqB{@yB_@yB|@iC?yBzAyBrF{@zAmAjAk@hBsBNqLpGsFjByBz@iCiBoC?qMLej@{J{y@rF_DxAgSfEcp@fN}EjAcVz@sExByBhCgIlJcB|@cBLoCdF{Al@aBz@g@xB{@\\cB^{@vCGhB\\zAFfDGxBe@l@aCjAFhC{AjAgChBu@NcBhBqB]qBl@qBjAqBjA}@|@aCzA{AhB_C\\aC^sBxAyBl@yAjBcBxA{AzA_D|@u@xBcAhB{AxBqBzAyBhBaCzAyBzAgChByBjAyBjB{BzA_Cz@yBzAiCzAyBzAyBxAqBjAkBzAyBjAiBjAcBlAaBjAkBjAiBzAkBjAqBzAiBjAu@z@cBjAiBzAyBjBcBxAiB|@aCNyB\\iC\\gCl@yBNaC?iC?gCLoDNqBLsB^aBjAkBhByB|@qBjA{@l@kBz@yBlAyBjA_DxByBjAxBvC?zAmJ}@iCbGFfDaMxMcFtD"},
     }) {
 
     //try it
-    auto input_shape = decode<std::vector<PointLL>>(example.first);
-    auto resampled = resample_spherical_polyline(input_shape, example.second);
+    auto input_shape = decode<std::vector<PointLL>>(example.second);
+    input_shape = {{9.284638166427612,47.271290961003956},{9.284638166427612,47.27015165787987},{9.283994436264038,47.269503736537516}};
+    auto resampled = resample_spherical_polyline(input_shape, example.first);
+
+
 
     std::cout << std::endl << "input" << std::endl;
     for(auto p : input_shape){
@@ -141,7 +138,7 @@ void TestResample() {
     //check that nothing is too far apart
     for(auto p = std::next(resampled.cbegin()); p != resampled.cend(); ++p) {
       auto dist = p->Distance(*std::prev(p));
-      if(dist > example.second + 1)
+      if(dist > example.first + 1)
         throw std::runtime_error("Distance between any two points on the resampled line cannot be further than resample distance");
     }
 

--- a/test/util.cc
+++ b/test/util.cc
@@ -1,6 +1,10 @@
 #include "test.h"
-#include "valhalla/midgard/util.h"
-#include "valhalla/midgard/distanceapproximator.h"
+#include "midgard/util.h"
+#include "midgard/distanceapproximator.h"
+#include "midgard/constants.h"
+
+#include <list>
+#include <iostream>
 
 using namespace valhalla::midgard;
 
@@ -125,11 +129,19 @@ void TestResample() {
     auto input_shape = decode<std::vector<PointLL>>(example.first);
     auto resampled = resample_spherical_polyline(input_shape, example.second);
 
+    std::cout << std::endl << "input" << std::endl;
+    for(auto p : input_shape){
+      std::cout << '[' << p.first << ',' << p.second << "],";
+    }
+    std::cout << std::endl << "output" << std::endl;
+    for(auto p : resampled){
+      std::cout << '[' << p.first << ',' << p.second << "],";
+    }
+
     //check that nothing is too far apart
-    for(auto p = resampled.cbegin() + 1; p != resampled.cend(); ++p) {
-      auto sqdist = DistanceApproximator::DistanceSquared(*p, *(p - 1));
-      auto dist = 1.f / FastInvSqrt(sqdist);
-      if(dist > example.second + 2)
+    for(auto p = std::next(resampled.cbegin()); p != resampled.cend(); ++p) {
+      auto dist = p->Distance(*std::prev(p));
+      if(dist > example.second + 1)
         throw std::runtime_error("Distance between any two points on the resampled line cannot be further than resample distance");
     }
 

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -64,15 +64,6 @@ class PointLL : public Point2 {
   float DistanceSquared(const PointLL& ll2) const;
 
   /**
-   * Compute the length of the polyline represented by a set of
-   * lat,lng points. Avoids having to copy the points into the
-   * polyline.
-   * @param  pts  List of lat,lng points.
-   * @return  Returns the length in meters
-   */
-  static float Length(const std::vector<PointLL>& pts);
-
-  /**
    * Calculates the curvature using this position and 2 others. Found by
    * computing the radius of the circle that circumscribes the 3 positions.
    * @param   ll1   Second lat,lng position

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -9,8 +9,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
-#include <functional>
-#include <vector>
 
 #include <valhalla/midgard/pointll.h>
 
@@ -176,7 +174,8 @@ T circular_range_clamp(T value, T lower, T upper) {
 /**
  * Resample a polyline in spherical coordinates
  */
-std::vector<PointLL> resample_spherical_polyline(const std::vector<PointLL>& polyline, float resolution);
+template<class container_t>
+container_t resample_spherical_polyline(const container_t& polyline, double resolution);
 
 }
 }

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -72,6 +72,17 @@ T sqr(const T a) {
   return a * a;
 }
 
+// Compute the length of the polyline represented by a set of lat,lng points.
+// Avoids having to copy the points into a polyline, polyline should really just extend
+// A container class like vector or list
+template <class container_t>
+float length(const container_t& pts) {
+ float length = 0.0f;
+ for(auto p = std::next(pts.cbegin()); p != pts.end(); ++p)
+   length += p->Distance(*std::prev(p));
+ return length;
+}
+
 /**
  * Polyline encode a container of points into a string
  * Note: newer versions of this algorithm allow one to specify a zoom level


### PR DESCRIPTION
this changes the way resampling works. first its a simpler algorithm. second, its more accurate at the cost of some heavier trig functions. ive tested this an it has zero impact where its used (getting elevation data) as that is dominated by the time to fetch values from memory mapped files. it works by computing the distance along the great arc segment instead of the flat earth segment.

i also did some template work to allow lists in addition to vectors from encode/decode which is nice because it removes the possibility of realloc. the reason for that is because when resampling you cant know how many points you'll have without first computing the length of the linestring and frankly for serializing that in a request or using it in mjolnir we dont need indexed access to individual points. so this could have the potential to speed up shape twiddling we do in data creation and in the elevation service.