### PR TITLE
fix grid intersect out of bounds

### DIFF
--- a/src/midgard/aabb2.cc
+++ b/src/midgard/aabb2.cc
@@ -1,6 +1,8 @@
 #include "midgard/aabb2.h"
 #include "midgard/linesegment2.h"
 #include "midgard/util.h"
+#include "midgard/point2.h"
+#include "midgard/pointll.h"
 
 namespace valhalla {
 namespace midgard {

--- a/src/midgard/grid.cc
+++ b/src/midgard/grid.cc
@@ -47,7 +47,7 @@ namespace valhalla {
 
       //for each segment
       for(auto u = linestring.cbegin(); u != linestring.cend(); std::advance(u, 1)) {
-        //get some infor on u
+        //get some info on u
         size_t x_start = static_cast<size_t>((clamp(u->first, super_cell.minx(), super_cell.maxx()) - super_cell.minx()) * x_index_coef);
         size_t y_start = static_cast<size_t>((clamp(u->second, super_cell.miny(), super_cell.maxy()) - super_cell.miny()) * y_index_coef);
         if(super_cell.Contains(*u)) {
@@ -67,12 +67,13 @@ namespace valhalla {
           std::swap(x_start, x_end);
         if(y_start > y_end)
           std::swap(y_start, y_end);
+        x_end = std::min(x_end + 1, divisions);
+        y_end = std::min(y_end + 1, divisions);
         for(; y_start <= y_end; ++y_start) {
-          for(size_t x = x_start; x <= x_end; ++x) {
+          for(size_t x = x_start; x < x_end; ++x) {
             size_t index = y_start * divisions + x;
-            if(cells[index].Intersects(*u, *v)) {
+            if(cells[index].Intersects(*u, *v))
               indices.insert(index);
-            }
           }
         }
       }
@@ -101,6 +102,16 @@ namespace valhalla {
 
       //give them back
       return indices;
+    }
+
+    template <class coord_t>
+    size_t grid<coord_t>::size() const {
+      return cells.size();
+    }
+
+    template <class coord_t>
+    const AABB2<coord_t>& grid<coord_t>::extent() const {
+      return super_cell;
     }
 
     //explicit instantiation

--- a/src/midgard/grid.cc
+++ b/src/midgard/grid.cc
@@ -69,7 +69,7 @@ namespace valhalla {
           std::swap(y_start, y_end);
         x_end = std::min(x_end + 1, divisions);
         y_end = std::min(y_end + 1, divisions);
-        for(; y_start <= y_end; ++y_start) {
+        for(; y_start < y_end; ++y_start) {
           for(size_t x = x_start; x < x_end; ++x) {
             size_t index = y_start * divisions + x;
             if(cells[index].Intersects(*u, *v))

--- a/test/grid.cc
+++ b/test/grid.cc
@@ -1,4 +1,6 @@
-#include "valhalla/midgard/grid.h"
+#include "midgard/grid.h"
+#include "midgard/point2.h"
+#include "midgard/pointll.h"
 #include "test.h"
 
 #include <list>

--- a/valhalla/midgard/aabb2.h
+++ b/valhalla/midgard/aabb2.h
@@ -2,9 +2,6 @@
 #define VALHALLA_MIDGARD_AABB2_H_
 
 #include <vector>
-
-#include <valhalla/midgard/point2.h>
-#include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/linesegment2.h>
 
 namespace valhalla {

--- a/valhalla/midgard/grid.h
+++ b/valhalla/midgard/grid.h
@@ -27,7 +27,7 @@ class grid {
   /**
    * Constructor for grid
    * @param extents    the extents of the grid in the form of an AABB2
-   * @param divisions  the number of divisions in the grid in both the x and y axis
+   * @param divisions  the number of rows/columns within the grid
    */
   grid(const AABB2<coord_t>& extents, size_t divisions);
 
@@ -35,7 +35,7 @@ class grid {
    * Constructor for grid
    * @param min        the minimum extreme point of the grid
    * @param max        the maximum extreme point of the grid
-   * @param divisions  the number of divisions in the grid in both the x and y axis
+   * @param divisions  the number of rows/columns within the grid
    */
   grid(const coord_t& min, const coord_t& max, size_t divisions);
 
@@ -56,6 +56,16 @@ class grid {
    * @return        the set of cells indices which intersect the circle
    */
   std::unordered_set<size_t> intersect(const coord_t& center, const float radius) const;
+
+  /**
+   * @return  the number of cells within this grid
+   */
+  size_t size() const;
+
+  /**
+   * @return  the extent encompasing this grid
+   */
+  const AABB2<coord_t>& extent() const;
 
  protected:
   size_t divisions;


### PR DESCRIPTION
what was happening is that you dont know which side of the intersected range is at the beginning or ending of a given linesegment. so to find the subset we clip the segment to the bounding box. we then find where those clipped points lie in terms of row col within the grid. the problem is when you loop over that range, if you ened up clipping the one side of the segment on the extreme edge (most positive x or y aligned edge) one of the variables in the loop range will be the dimension of the grid itself which is essentially out of bounds.

so the fix was simple. change the range to < instead of <= and add 1 to the end of the range but clamp it to the dimension in case it goes over that.

this was very hard to explain so if you didnt understand anything i am saying then feel free to rubber stamp ;)