### PR TITLE
sphereical coordinate midpoint, grid intersection efficiency and neighbors

### DIFF
--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -52,24 +52,29 @@ float PointLL::DistanceSquared(const PointLL& ll2) const {
 // Mid point along the geodesic between these points
 PointLL PointLL::MidPoint(const PointLL& p) const {
   //radians
-  auto lon1 = first * -RAD_PER_DEG;
-  auto lat1 = second * RAD_PER_DEG;
-  auto lon2 = p.first * -RAD_PER_DEG;
-  auto lat2 = p.second * RAD_PER_DEG;
+  const auto lon1 = first * -RAD_PER_DEG;
+  const auto lat1 = second * RAD_PER_DEG;
+  const auto lon2 = p.first * -RAD_PER_DEG;
+  const auto lat2 = p.second * RAD_PER_DEG;
+  //useful throughout
+  const auto sl1 = sin(lat1);
+  const auto sl2 = sin(lat2);
+  const auto cl1 = cos(lat1);
+  const auto cl2 = cos(lat2);
   //fairly accurate distance between points
-  auto d = acos(
-    sin(second * RAD_PER_DEG) * sin(lat2) +
-    cos(second * RAD_PER_DEG) * cos(lat2) *
-    cos(first * -RAD_PER_DEG - lon2)
+  const auto d = acos(
+    sl1 * sl2 +
+    cl1 * cl2 *
+    cos(lon1 - lon2)
   );
   //interpolation parameters
-  auto ab = sin(d * .5) / sin(d);
-  auto acs1 = ab * cos(lat1);
-  auto bcs2 = ab * cos(lat2);
+  const auto ab = sin(d * .5) / sin(d);
+  const auto acs1 = ab * cl1;
+  const auto bcs2 = ab * cl2;
   //find the interpolated point along the arc
-  auto x = acs1 * cos(lon1) + bcs2 * cos(lon2);
-  auto y = acs1 * sin(lon1) + bcs2 * sin(lon2);
-  auto z = ab * (sin(lat1) + sin(lat2));
+  const auto x = acs1 * cos(lon1) + bcs2 * cos(lon2);
+  const auto y = acs1 * sin(lon1) + bcs2 * sin(lon2);
+  const auto z = ab * (sl1 + sl2);
   return PointLL(atan2(y, x) * -DEG_PER_RAD, atan2(z, sqrt(x * x + y * y)) * DEG_PER_RAD);
 }
 

--- a/test/pointll.cc
+++ b/test/pointll.cc
@@ -220,6 +220,45 @@ void TestWithinConvexPolygon() {
   TryWithinConvexPolygon(pts, PointLL( 1.0f,-3.5f), false);
 }
 
+void TestMidPoint() {
+  //lines of longitude are geodesics so the mid point of points
+  //on the same line of longitude should still be at the same longitude
+  auto mid = PointLL(0, 90).MidPoint({0, 0});
+  if(mid != PointLL(0, 45))
+    throw std::logic_error("Wrong mid point");
+  mid = PointLL(0, 90).MidPoint({0, -66});
+  if(mid != PointLL(0,12))
+    throw std::logic_error("Wrong mid point");
+  mid = PointLL(-23, 45).MidPoint({157, 45});
+  if(mid != PointLL(0, 90))
+    throw std::logic_error("Wrong mid point");
+
+  //in the northern hemisphere we should expect midpoints on
+  //geodesics between point of the same latitude to have higher latitude
+  mid = PointLL(-15, 45).MidPoint({15, 45});
+  if(mid.second <= 45.1)
+    throw std::logic_error("Wrong mid point");
+  mid = PointLL(-80, 1).MidPoint({80, 1});
+  if(mid.second <= 1.1)
+    throw std::logic_error("Wrong mid point");
+
+  //conversely in the southern hemisphere we should expect them lower
+  mid = PointLL(-15, -45).MidPoint({15, -45});
+  if(mid.second >= -45.1)
+    throw std::logic_error("Wrong mid point");
+  mid = PointLL(-80, -1).MidPoint({80, -1});
+  if(mid.second >= -1.1)
+    throw std::logic_error("Wrong mid point");
+
+  //the equator is the only line of latitude that is also a geodesic
+  mid = PointLL(-15, 0).MidPoint({15, 0});
+  if(mid != PointLL(0, 0))
+    throw std::logic_error("Wrong mid point");
+  mid = PointLL(-170, 0).MidPoint({160, 0});
+  if(mid != PointLL(175, 0))
+    throw std::logic_error("Wrong mid point");
+}
+
 }
 
 int main(void) {
@@ -238,6 +277,9 @@ int main(void) {
 
   // Test if within polygon
   suite.test(TEST_CASE(TestWithinConvexPolygon));
+
+  // Test midpoint
+  suite.test(TEST_CASE(TestMidPoint));
 
   //TODO: many more!
 

--- a/valhalla/midgard/grid.h
+++ b/valhalla/midgard/grid.h
@@ -2,6 +2,7 @@
 #define VALHALLA_MIDGARD_GRID_H_
 
 #include <vector>
+#include <list>
 #include <unordered_set>
 
 #include <valhalla/midgard/aabb2.h>
@@ -68,6 +69,15 @@ class grid {
   const AABB2<coord_t>& extent() const;
 
  protected:
+
+  /**
+   * Update the neighboring grids that a segment of linestring bleeds into
+   * @param  the first point on the segment
+   * @param  the second point on the segment
+   * @param  the set of neighbors to update with this segments information
+   */
+  std::list<std::pair<int, int> > update_neighbors(const coord_t& a, const coord_t& b) const;
+
   size_t divisions;
   AABB2<coord_t> super_cell;
   std::vector<AABB2<coord_t> > cells;

--- a/valhalla/midgard/pointll.h
+++ b/valhalla/midgard/pointll.h
@@ -48,6 +48,13 @@ class PointLL : public Point2 {
   void Invalidate();
 
   /**
+   * Gets the midpoint on a line segment between this point and point p1.
+   * @param   p1  Point
+   * @return  Returns the midpoint between this point and p1.
+   */
+  PointLL MidPoint(const PointLL& p1) const;
+
+  /**
    * Calculates the distance between two lat/lng's in meters. Uses spherical
    * geometry (law of cosines).
    * @param   ll2   Second lat,lng position to calculate distance to.


### PR DESCRIPTION
this adds the ability to get the mid point along the geodesic between two spherical coordinates. it adds test for that as well. oh i should mention that this mid point thing is useful for interfacing with other systems which use a canonical interpretation of lat,lon projected geometries. we make a simplification by assuming that the world is flat, they, properly do not. this will be used in transit_fetcher to do proper tile intersection with transit.land geographies

also changes the way grid intersection was done to allow for more efficient computation of the intersecting subcells. this approach will also be used to return information about the intersecting neighbor grids should a segment leave the grid in question.