### PR TITLE
square peg, round hole

### DIFF
--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -43,9 +43,9 @@ float Polyline2<coord_t>::Length() const {
 
 // Find the length of the supplied polyline.
 template <class coord_t>
-float Polyline2<coord_t>::Length(const std::vector<coord_t>& pts) const {
+float Polyline2<coord_t>::Length(const std::vector<coord_t>& pts) {
   float length = 0;
-  for (uint32_t i = 0; i < pts_.size() - 1; i++) {
+  for (uint32_t i = 0; i < pts.size() - 1; i++) {
     length += pts[i].Distance(pts[i+1]);
   }
   return length;

--- a/src/midgard/polyline2.cc
+++ b/src/midgard/polyline2.cc
@@ -1,6 +1,7 @@
 #include "valhalla/midgard/polyline2.h"
 
 #include <vector>
+#include <list>
 
 namespace valhalla {
 namespace midgard {
@@ -35,19 +36,22 @@ void Polyline2<coord_t>::Add(const coord_t& p) {
 template <class coord_t>
 float Polyline2<coord_t>::Length() const {
   float length = 0;
-  for (uint32_t i = 0; i < pts_.size() - 1; i++) {
-    length += pts_[i].Distance(pts_[i+1]);
-  }
+  if (pts_.size() < 2)
+    return length;
+  for (auto p = std::next(pts_.cbegin()); p != pts_.cend(); ++p)
+    length += std::prev(p)->Distance(*p);
   return length;
 }
 
 // Find the length of the supplied polyline.
 template <class coord_t>
-float Polyline2<coord_t>::Length(const std::vector<coord_t>& pts) {
+template <class container_t>
+float Polyline2<coord_t>::Length(const container_t& pts) {
   float length = 0;
-  for (uint32_t i = 0; i < pts.size() - 1; i++) {
-    length += pts[i].Distance(pts[i+1]);
-  }
+  if (pts.size() < 2)
+    return length;
+  for (auto p = std::next(pts.cbegin()); p != pts.cend(); ++p)
+    length += std::prev(p)->Distance(*p);
   return length;
 }
 
@@ -142,6 +146,11 @@ void Polyline2<coord_t>::DouglasPeucker(const uint32_t i, const uint32_t j,
 // Explicit instantiation
 template class Polyline2<Point2>;
 template class Polyline2<PointLL>;
+
+template float Polyline2<PointLL>::Length(const std::vector<PointLL>&);
+template float Polyline2<Point2>::Length(const std::vector<Point2>&);
+template float Polyline2<PointLL>::Length(const std::list<PointLL>&);
+template float Polyline2<Point2>::Length(const std::list<Point2>&);
 
 }
 }

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -306,7 +306,9 @@ container_t resample_spherical_polyline(const container_t& polyline, double reso
 
 //explicit instantiations
 template std::vector<PointLL> resample_spherical_polyline<std::vector<PointLL> >(const std::vector<PointLL>&, double, bool);
+template std::vector<Point2> resample_spherical_polyline<std::vector<Point2> >(const std::vector<Point2>&, double, bool);
 template std::list<PointLL> resample_spherical_polyline<std::list<PointLL> >(const std::list<PointLL>&, double, bool);
+template std::list<Point2> resample_spherical_polyline<std::list<Point2> >(const std::list<Point2>&, double, bool);
 
 //Return the intersection of two infinite lines if any
 template <class coord_t>

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -249,16 +249,12 @@ std::ostream& operator<<(std::ostream& stream, const memory_status& s){
  * We humbly bow to you sir!
  */
 template <class container_t>
-container_t resample_spherical_polyline(const container_t& polyline, double resolution) {
-  //start out with the first point
-  container_t resampled;
+container_t resample_spherical_polyline(const container_t& polyline, double resolution, bool preserve) {
   if(polyline.size() == 0)
-    return resampled;
-  resampled.emplace_back(polyline.front());
-  if(polyline.size() == 1)
-    return resampled;
+    return {};
 
   //for each point
+  container_t resampled = {polyline.front()};
   resolution *= RAD_PER_METER;
   double remaining = resolution;
   PointLL last = resampled.back();
@@ -298,6 +294,8 @@ container_t resample_spherical_polyline(const container_t& polyline, double reso
     //we're going to the next point so consume whatever's left
     remaining -= d;
     last = *p;
+    if(preserve)
+      resampled.push_back(last);
   }
 
   //TODO: do we want to let them know remaining?
@@ -307,8 +305,8 @@ container_t resample_spherical_polyline(const container_t& polyline, double reso
 }
 
 //explicit instantiations
-template std::vector<PointLL> resample_spherical_polyline<std::vector<PointLL> >(const std::vector<PointLL>&, double);
-template std::list<PointLL> resample_spherical_polyline<std::list<PointLL> >(const std::list<PointLL>&, double);
+template std::vector<PointLL> resample_spherical_polyline<std::vector<PointLL> >(const std::vector<PointLL>&, double, bool);
+template std::list<PointLL> resample_spherical_polyline<std::list<PointLL> >(const std::list<PointLL>&, double, bool);
 
 //Return the intersection of two infinite lines if any
 template <class coord_t>

--- a/test/util.cc
+++ b/test/util.cc
@@ -120,7 +120,7 @@ void TestResample() {
 
     //try it
     auto input_shape = decode<std::vector<PointLL>>(example.second);
-    auto resampled = resample_spherical_polyline(input_shape, example.first);
+    auto resampled = resample_spherical_polyline(input_shape, example.first, false);
 
     //check that nothing is too far apart
     for(auto p = std::next(resampled.cbegin()); p != resampled.cend(); ++p) {
@@ -130,13 +130,25 @@ void TestResample() {
     }
 
     //all the points better be within a meter or so of the original line
-    for(const auto p : resampled) {
+    for(const auto& p : resampled) {
       auto cp = p.ClosestPoint(input_shape);
       auto dist = std::get<1>(cp);
       if(!equal(dist, 0.f, 1.2f)) {
         throw std::runtime_error("Sampled point was not found on original line");
       }
     }
+
+    //all the original points should be in this one
+    resampled = resample_spherical_polyline(input_shape, example.first, true);
+    auto current = resampled.cbegin();
+    for(const auto& p : input_shape) {
+      while(current != resampled.cend() && *current != p)
+        ++current;
+      if(current == resampled.cend())
+        throw std::runtime_error("All original points should be found in resampled polyline");
+    }
+    if(current + 1 != resampled.cend())
+      throw std::runtime_error("Last found point should be last point in resampled polyline");
   }
 }
 

--- a/valhalla/midgard/polyline2.h
+++ b/valhalla/midgard/polyline2.h
@@ -52,7 +52,8 @@ class Polyline2 {
    * @param   pts  Polyline vertices.
    * @return  Returns the length of the polyline.
    */
-  static float Length(const std::vector<coord_t>& pts);
+  template <class container_t>
+  static float Length(const container_t& pts);
 
   /**
    * Finds the closest point to the supplied polyline as well as the distance

--- a/valhalla/midgard/polyline2.h
+++ b/valhalla/midgard/polyline2.h
@@ -52,7 +52,7 @@ class Polyline2 {
    * @param   pts  Polyline vertices.
    * @return  Returns the length of the polyline.
    */
-  float Length(const std::vector<coord_t>& pts) const;
+  static float Length(const std::vector<coord_t>& pts);
 
   /**
    * Finds the closest point to the supplied polyline as well as the distance

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -194,7 +194,7 @@ T clamp(T value, T lower, T upper) {
 /**
  * Resample a polyline in spherical coordinates to specified resolution optionally keeping all original points in the line
  * @param polyline     the list/vector of points in the line
- * @param resolution   minimum distance between any point in the resampled line
+ * @param resolution   maximum distance between any two points in the resampled line
  * @param preserve     keep input points in resampled line or not
  */
 template<class container_t>

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -192,10 +192,13 @@ T clamp(T value, T lower, T upper) {
 }
 
 /**
- * Resample a polyline in spherical coordinates
+ * Resample a polyline in spherical coordinates to specified resolution optionally keeping all original points in the line
+ * @param polyline     the list/vector of points in the line
+ * @param resolution   minimum distance between any point in the resampled line
+ * @param preserve     keep input points in resampled line or not
  */
 template<class container_t>
-container_t resample_spherical_polyline(const container_t& polyline, double resolution);
+container_t resample_spherical_polyline(const container_t& polyline, double resolution, bool preserve = false);
 
 /**
  * A class to wrap a primitive array in something iterable which is useful for loops mostly


### PR DESCRIPTION
this pr makes sure to resample long edges' shapes for binning so that we dont incorrectly bin portions of the edge.

because of geodesics, straight lines between two points on a sphere, dont follow the same rules as straight lines in the plane, when we bin edges into our planar grid we must do a little more work. this pr attempts to approximate a long geodesic via piecewise approximation that should be fine enough to remove incorrectly binned sections of an edge.