### PR TITLE
closest first subdivision iteration

### DIFF
--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -87,9 +87,9 @@ float PointLL::Distance(const PointLL& ll2) const {
 
   // Delta longitude. Don't need to worry about crossing 180
   // since cos(x) = cos(-x)
-  double deltalng = (ll2.lng() - lng()) * kRadPerDeg;
-  double a = lat() * kRadPerDeg;
-  double c = ll2.lat() * kRadPerDeg;
+  double deltalng = (ll2.lng() - lng()) * RAD_PER_DEG;
+  double a = lat() * RAD_PER_DEG;
+  double c = ll2.lat() * RAD_PER_DEG;
 
   // Find the angle subtended in radians (law of cosines)
   double cosb = (sin(a) * sin(c)) + (cos(a) * cos(c) * cos(deltalng));

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -80,33 +80,28 @@ namespace {
     }
 
     //something to add the neighbors of a given subdivision
+    const std::list<std::pair<int, int> > neighbor_offsets{ {0,-1}, {-1,0}, {1,0}, {0,1} };
     void neighbors(int32_t s) {
       //walk over all adjacent subdivisions in row major order
       auto x = s % subcols;
       auto y = s / subcols;
-      for(auto i = -1; i < 2; ++i) {
+      for(const auto& off : neighbor_offsets) {
         //skip y out of bounds
-        auto ny = y + i;
+        auto ny = y + off.second;
         if(ny == -1 || ny == subrows)
           continue;
-        //do x
-        for(auto j = -1; j < 2; ++j) {
-          //skip if exactly one of them isnt zero
-          if(j == 0 && i == 0)
+        //fix x
+        auto nx = x + off.first;
+        if(nx == -1 || nx == subcols){
+          if(!coord_t::IsSpherical())
             continue;
-          //fix x
-          auto nx = x + j;
-          if(nx == -1 || nx == subcols){
-            if(!coord_t::IsSpherical())
-              continue;
-            nx = (nx + subcols) % subcols;
-          }
-          //actually add the thing
-          auto neighbor = ny * subcols + nx;
-          if(queued.find(neighbor) == queued.cend()) {
-            queued.emplace(neighbor);
-            queue.emplace(std::make_pair(dist(neighbor), neighbor));
-          }
+          nx = (nx + subcols) % subcols;
+        }
+        //actually add the thing
+        auto neighbor = ny * subcols + nx;
+        if(queued.find(neighbor) == queued.cend()) {
+          queued.emplace(neighbor);
+          queue.emplace(std::make_pair(dist(neighbor), neighbor));
         }
       }
     }

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -97,7 +97,7 @@ namespace {
               continue;
             nx = (nx + subcols) % subcols;
           }
-          //fix y
+          //fix y TODO: this is wrong
           if(ny == -1 || ny == subrows){
             if(!coord_t::IsSpherical())
               continue;

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -82,27 +82,25 @@ namespace {
 
     //something to add the neighbors of a given subdivision
     void neighbors(int32_t s) {
-      //walk over all adjacent subdivisions
+      //walk over all adjacent subdivisions in row major order
       auto x = s % subcols;
       auto y = s / subcols;
       for(auto i = -1; i < 2; ++i) {
+        //skip y out of bounds
+        auto ny = y + i;
+        if(ny == -1 || ny == subrows)
+          continue;
+        //do x
         for(auto j = -1; j < 2; ++j) {
-          if(i == 0 && j == 0)
+          //skip if exactly one of them isnt zero
+          if(j == 0 && i == 0)
             continue;
-          auto nx = x + j;
-          auto ny = y + i;
           //fix x
+          auto nx = x + j;
           if(nx == -1 || nx == subcols){
             if(!coord_t::IsSpherical())
               continue;
             nx = (nx + subcols) % subcols;
-          }
-          //fix y TODO: this is wrong
-          if(ny == -1 || ny == subrows){
-            if(!coord_t::IsSpherical())
-              continue;
-            ny = std::min(std::max(ny, 0), subrows - 1);
-            nx = (nx + subcols / 2) % subcols;
           }
           //actually add the thing
           auto neighbor = ny * subcols + nx;

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -78,7 +78,7 @@ namespace {
       //if its purely horizontal then dont use a corner
       if(sy > seed_y && sy - 1 < seed_y)
         c.second = seed.second;
-      return seed.DistanceSquared(c);
+      return seed.Distance(c);
     }
 
     //something to add the neighbors of a given subdivision

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -4,7 +4,6 @@
 #include "midgard/distanceapproximator.h"
 #include <cmath>
 #include <set>
-#include <iostream>
 
 namespace {
 

--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -63,21 +63,25 @@ namespace {
 
     //something to measure the closest possible point of a subdivision from the given seed point
     float dist(int32_t sub) {
+      int32_t x_off = 0;
       auto sx = sub % subcols;
       if (sx < seed_x) {
         if(!coord_t::IsSpherical() || seed_x - sx < subcols / 2.f)
-          ++sx;
+          x_off = 1;
       }
       else if(coord_t::IsSpherical() && sx - seed_x > subcols / 2.f)
-        ++sx;
-      auto sy = sub / subcols; if (sy < seed_y) ++sy;
-      coord_t c(tiles.TileBounds().minx() + sx * tiles.SubdivisionSize(), tiles.TileBounds().miny() + sy * tiles.SubdivisionSize());
+        x_off = 1;
+      int32_t y_off = 0;
+      auto sy = sub / subcols; if (sy < seed_y) y_off = 1;
+      coord_t c(tiles.TileBounds().minx() + (sx + x_off) * tiles.SubdivisionSize(),
+        tiles.TileBounds().miny() + (sy + y_off) * tiles.SubdivisionSize());
       //if its purely vertical then dont use a corner
-      if(sx > seed_x && sx - 1 < seed_x)
+      if(x_off && sx < seed_x && sx + x_off > seed_x)
         c.first = seed.first;
       //if its purely horizontal then dont use a corner
-      if(sy > seed_y && sy - 1 < seed_y)
+      if(y_off && sy < seed_y && sy + y_off > seed_y)
         c.second = seed.second;
+      //return coord_t::IsSpherical() ? ::dist(seed, c) : seed.Distance(c);
       return seed.Distance(c);
     }
 
@@ -88,7 +92,7 @@ namespace {
       auto y = s / subcols;
       for(auto i = -1; i < 2; ++i) {
         for(auto j = -1; j < 2; ++j) {
-          if(i==0 && j == 0)
+          if(i == 0 && j == 0)
             continue;
           auto nx = x + j;
           auto ny = y + i;

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -287,6 +287,13 @@ void test_closest_first() {
     throw std::logic_error("Should have been wrapped to 8");
   if(to_global_sub(y(), t) != 23)
     throw std::logic_error("Should have been above to 23");
+  y = t.ClosestFirst({-179.99, -16.825});
+  if(to_global_sub(y(), t) != 8)
+    throw std::logic_error("Should have been 8");
+  if(to_global_sub(y(), t) != 15)
+    throw std::logic_error("Should have been wrapped to 15");
+  if(to_global_sub(y(), t) != 16)
+    throw std::logic_error("Should have been above to 16");
 
   //check antimeridian wrapping
   t = Tiles<PointLL>(AABB2<PointLL>{-180,-90,180,90}, .25, 5);

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -5,7 +5,6 @@
 #include "midgard/util.h"
 
 #include <random>
-#include <iostream>
 
 using namespace valhalla::midgard;
 

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -276,7 +276,7 @@ std::set<sub_t, std::function<bool (const sub_t&, const sub_t&)> > closest_first
 
 void test_closest_first() {
   Tiles<Point2> t(AABB2<Point2>{-10,-10,10,10}, 1, 5);
-  for(const auto& p : std::list<Point2>{ {0,0}, {-1.99,-1.99}, {-.03,1.2} }) {
+  for(const auto& p : std::list<Point2>{ {0,0}, {-1.99,-1.99}, {-.03,1.21} }) {
     auto c = t.ClosestFirst(p);
     auto a = closest_first_answer<Point2>(t, p);
     for(const auto& s : a) {

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <cstdint>
+#include <functional>
 
 #include <valhalla/midgard/constants.h>
 #include <valhalla/midgard/aabb2.h>
@@ -45,6 +46,12 @@ class Tiles {
   float TileSize() const;
 
   /**
+   * Get the tile subdivision size.
+   * @return tile subdivision size.
+   */
+  float SubdivisionSize() const;
+
+  /**
    * Get the number of rows in the tiling system.
    * @return  Returns the number of rows.
    */
@@ -55,6 +62,12 @@ class Tiles {
    * @return  Returns the number of columns.
    */
   int32_t ncolumns() const;
+
+  /**
+   * Get the number of subdivisions in a tile in the tiling system.
+   * @return  Returns the number of subdivisions.
+   */
+  unsigned short nsubdivisions() const;
 
   /**
    * Get the bounding box of the tiling system.
@@ -243,12 +256,13 @@ class Tiles {
   std::unordered_map<int32_t, std::unordered_set<unsigned short> > Intersect(const container_t& linestring) const;
 
   /**
-   * Intersect a circle with the tiles to see which tiles and sub cells it intersects
-   * @param center  the center of the circle
-   * @param radius  the radius of the circle
-   * @return        the map of each tile intersected to a list of its intersected sub cell indices
+   * Returns a functor which returns subdivisions close to the original point on each invocation in a best first fashion
+   * If the functor can't expand any further (no more subdivisions) it will throw
+   * @param seed   the point at for which we measure 'closeness'
+   * @return       the functor to be called
    */
-  std::unordered_map<int32_t, std::unordered_set<unsigned short> > Intersect(const coord_t& center, const float radius) const;
+  std::function<std::tuple<int32_t, unsigned short, float>() > ClosestFirst(const coord_t& seed) const;
+
 
  protected:
   // Bounding box of the tiling system.


### PR DESCRIPTION
for `loki` to to check bins of tiles we need a means of iterating over subdivision within the `Tiles` object. optimally we would want to iterate over the closest ones to the input point first. the reason we'd want to do this is so that we can terminate the iteration as soon as possible. basically if you find a candidate in one subdivsion/bin and its `x` distance away from the input point. as soon as you hit a subdivision whose closest point to the input is greater than `x` then you know you can stop and not even consider that subdivsion/bin or any subsequent once (since its closest first).

the tests are currently working but the last one fails because of a precision issue in sorting..i'll resolve that before merging of course. i also need to add a few more tests. then we can start using this in `loki`