### PR TITLE
subtile intersection to fix binning

### DIFF
--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -517,12 +517,16 @@ std::unordered_map<int32_t, std::unordered_set<unsigned short> > Tiles<coord_t>:
     auto x1 = (v.first - tilebounds_.minx()) / tilebounds_.Width() * ncolumns_ * nsubdivisions_;
     auto y1 = (v.second - tilebounds_.miny()) / tilebounds_.Height() * nrows_ * nsubdivisions_;
 
+    int ix0 = std::floor(x0), ix1 = std::floor(x1);
+    int iy0 = std::floor(y0), iy1 = std::floor(y1);
+    int dx = ix0 - ix1, dy = iy0 - iy1;
+    int ds = dx*dx + dy*dy;
     //its likely for our use case that its all in one cell
-    if(static_cast<int>(x0) == static_cast<int>(x1) && static_cast<int>(y0) == static_cast<int>(y1))
-      set_pixel(std::floor(x0), std::floor(y0));
+    if(ds == 0) { set_pixel(ix0, iy0); }
+    //if not the next most likley thing is adjacent cells
+    else if(ds == 1) { set_pixel(ix0, iy0); set_pixel(ix1, iy1); }
     //pretend the subdivisions are pixels and we are doing line rasterization
-    else
-      bresenham_line(x0, y0, x1, y1, set_pixel);
+    else { bresenham_line(x0, y0, x1, y1, set_pixel); }
   }
 
   //give them back

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -201,6 +201,15 @@ void test_intersect_linestring() {
   for(const auto& i : intersection)
     if(i.first != 791318)
       throw std::logic_error("This tile shouldn't be intersected: " + std::to_string(i.first));
+
+  shape = {{130.399643, 33.6005592}, {130.399994, 33.5999985}};
+  intersection = ll.Intersect(shape);
+  size_t count = 0;
+  for(const auto& i : intersection)
+    count += i.second.size();
+  if(count > 2)
+    throw std::logic_error("Should not have " + std::to_string(count) + " intersections for this shape");
+
 }
 
 void test_random_linestring() {


### PR DESCRIPTION
sometimes two points on a linestring are so close together that their slope cannot be accurately computed. this is not good because it causes algorithms similar to bresenhams to go past the target pixel. the thing about degenerate cases is that they are very short. so the source pixel and the target pixel must be close together. we already had a check in there for when the source and target were the same pixel. we didnt check if the source and target were adjacent pixels though (this should be pretty common). so i've added that check here. it should not only fix the bug but also make the binning faster.

note that the fix essentially involves figuring out when something is trivial and hardcoding the answers for those cases. this is what gives the speedup. it turns out that the degenerate cases are equivalent to the trivial cases so we luck out.

one more note, this does not avoid sending all degenerate cases to bresenhams. particularly there is one additional case where the slope cant be computed accurately and the source and target pixels are not adjacent they are diagonal. the good news is, it doesnt matter. in that case bresenhams will pick one axis of the diagonal first and the other second (probably y first and then x second). we dont really care because the answer is still correct.