### PR TITLE
be robust to tars that have corruption or are concatinated archives

### DIFF
--- a/valhalla/midgard/sequence.h
+++ b/valhalla/midgard/sequence.h
@@ -384,6 +384,7 @@ struct tar {
     }
     bool is_ustar() const { return (memcmp("ustar", magic, 5) == 0); }
     size_t get_file_size() const { return octal_to_int(size); }
+    bool blank() const { constexpr header_t BLANK{}; return !memcmp(this, &BLANK, sizeof(header_t)); }
     bool verify() const {
       //make a copy and blank the checksum
       header_t temp = *this; memset(temp.chksum, ' ', 8); int64_t usum = 0, sum = 0;
@@ -396,23 +397,26 @@ struct tar {
       uint64_t rsum = octal_to_int(chksum);
       return rsum == usum || rsum == sum;
     }
+
   };
 
-  tar(const std::string& tar_file, bool regular_files_only = true):tar_file(tar_file),skipped_blocks(0) {
+  tar(const std::string& tar_file, bool regular_files_only = true):tar_file(tar_file),corrupt_blocks(0) {
     //map the file
     struct stat s;
     if(stat(tar_file.c_str(), &s) || s.st_size == 0 || (s.st_size % sizeof(header_t)) != 0)
       return;
     try { mm.map(tar_file, s.st_size); } catch (...) { return; }
     //rip through the tar to see whats in it noting that most tars end with 2 empty blocks
-    //but we can concatinate tars and get them in between so we'll just be pretty lax about it
+    //but we can concatenate tars and get empty blocks in between so we'll just be pretty
+    //lax about it and we'll count the ones we cant make sense of
+    constexpr header_t BLANK{};
     const char* position = mm.get();
     while(position < mm.get() + mm.size()) {
       //get the header for this file
       const header_t* h = static_cast<const header_t*>(static_cast<const void*>(position));
       position += sizeof(header_t);
       //if it doesnt checkout ignore it and move on one block at a time
-      if(!h->verify()) { ++skipped_blocks; continue; }
+      if(!h->verify()) { corrupt_blocks += !h->blank(); continue; }
       auto size = h->get_file_size();
       //do we record entry file or not
       if(!regular_files_only || (h->typeflag == '0' || h->typeflag == '\0'))
@@ -428,7 +432,7 @@ struct tar {
   using entry_name_t = std::string;
   using entry_location_t = std::pair<const char*, size_t>;
   std::unordered_map<entry_name_t, entry_location_t> contents;
-  size_t skipped_blocks;
+  size_t corrupt_blocks;
 };
 
 }


### PR DESCRIPTION
we also have the option to warn in baldr graphreader if some of the blocks in the archive are skipped.