### PR TITLE
Minor fixes and workarounds for VC compatibility

### DIFF
--- a/src/midgard/pointll.cc
+++ b/src/midgard/pointll.cc
@@ -8,7 +8,7 @@
 #include <list>
 
 namespace {
-const float INVALID = 0xBADBADBAD;
+constexpr float INVALID = 0xBADBADBAD;
 
 constexpr double RAD_PER_DEG = M_PI / 180.0;
 constexpr double DEG_PER_RAD = 180.0 / M_PI;

--- a/src/midgard/util.cc
+++ b/src/midgard/util.cc
@@ -4,6 +4,8 @@
 #include "valhalla/midgard/distanceapproximator.h"
 
 #include <cstdint>
+#include <cctype>
+#include <cmath>
 #include <stdlib.h>
 #include <sstream>
 #include <fstream>

--- a/valhalla/midgard/point2.h
+++ b/valhalla/midgard/point2.h
@@ -24,7 +24,9 @@ class Point2 : public std::pair<float, float>{
   /**
    * Use the constructors provided by pair
    */
-  using std::pair<float, float>::pair;
+  Point2() = default;
+  Point2(const std::pair<float, float>& p) : pair(p) { }
+  Point2(float x, float y) : pair(x, y) { }
 
   /**
    * Destructor

--- a/valhalla/midgard/util.h
+++ b/valhalla/midgard/util.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <ostream>
 #include <utility>
+#include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>


### PR DESCRIPTION
Just a note: using std::pair<float, float>::pair for automatically declaring constructors causes Internal Compiler Error in Visual C++ v14 (Visual Studio 2015), thus I used a workaround