### PR TITLE
Add function for tiles intersecting a bounding box

### DIFF
--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -359,6 +359,15 @@ void test_closest_first() {
   }
 }
 
+void test_intersect_bbox() {
+  AABB2<PointLL> world_box{-180,-90,180,90};
+  Tiles<PointLL> t(world_box, 90, 2);
+  auto intersection = t.Intersect(world_box);
+  if (intersection.size() != t.TileCount()) {
+    throw std::runtime_error("Expected " + std::to_string(t.TileCount()) + " tiles returned from world-spanning intersection, but got " + std::to_string(intersection.size()) + " instead.");
+  }
+}
+
 }
 
 int main() {
@@ -381,6 +390,8 @@ int main() {
   suite.test(TEST_CASE(test_closest_first));
 
   suite.test(TEST_CASE(test_random_linestring));
+
+  suite.test(TEST_CASE(test_intersect_bbox));
 
   return suite.tear_down();
 }

--- a/valhalla/midgard/tiles.h
+++ b/valhalla/midgard/tiles.h
@@ -256,6 +256,16 @@ class Tiles {
   std::unordered_map<int32_t, std::unordered_set<unsigned short> > Intersect(const container_t& linestring) const;
 
   /**
+   * Intersect the bounding box with the tiles to see which tiles and sub-cells
+   * (a.k.a bins) it intersects with. This can be used to reduce the number of
+   * tiles and bins to search for matching items.
+   *
+   * @param box the bounding box to be tested.
+   * @return    a map of tile IDs to a set of bin IDs with that tile.
+   */
+  std::unordered_map<int32_t, std::unordered_set<uint16_t> > Intersect(const AABB2<coord_t> &box) const;
+
+  /**
    * Returns a functor which returns subdivisions close to the original point on each invocation in a best first fashion
    * If the functor can't expand any further (no more subdivisions) it will throw
    * @param seed   the point at for which we measure 'closeness'


### PR DESCRIPTION
There's a `Tiles::Intersect` function which returns the tiles and subdivisions (a.k.a. bins) intersecting a linestring. This adds an overload of that which takes a bounding box instead. This might be helpful for other parts of the code which want to iterate over the tiles and bins within an area.

@kevinkreiser could you review, please?