### PR TITLE
Multiply before dividing in order to preserve precision. 

### DIFF
--- a/src/midgard/tiles.cc
+++ b/src/midgard/tiles.cc
@@ -542,10 +542,12 @@ std::unordered_map<int32_t, std::unordered_set<uint16_t> > Tiles<coord_t>::Inter
   // then iterate over them to fill in each "pixel" or bin.
   const int32_t x_pixels = ncolumns_ * nsubdivisions_;
   const int32_t y_pixels = nrows_ * nsubdivisions_;
-  int32_t x0 = std::floor((box.minx() - tilebounds_.minx()) / tilebounds_.Width() * x_pixels);
-  int32_t y0 = std::floor((box.miny() - tilebounds_.miny()) / tilebounds_.Height() * y_pixels);
-  int32_t x1 = std::floor((box.maxx() - tilebounds_.minx()) / tilebounds_.Width() * x_pixels);
-  int32_t y1 = std::floor((box.maxy() - tilebounds_.miny()) / tilebounds_.Height() * y_pixels);
+  // NOTE: multiply by pixels before dividing to keep as much precision as
+  // possible.
+  int32_t x0 = std::floor(((box.minx() - tilebounds_.minx()) * x_pixels) / tilebounds_.Width());
+  int32_t y0 = std::floor(((box.miny() - tilebounds_.miny()) * y_pixels) / tilebounds_.Height());
+  int32_t x1 = std::floor(((box.maxx() - tilebounds_.minx()) * x_pixels) / tilebounds_.Width());
+  int32_t y1 = std::floor(((box.maxy() - tilebounds_.miny()) * y_pixels) / tilebounds_.Height());
 
   // clamp ranges to within the bounds of the tile.
   if (x0 < 0) { x0 = 0; }

--- a/test/tiles.cc
+++ b/test/tiles.cc
@@ -403,6 +403,26 @@ void test_intersect_bbox_single() {
   }
 }
 
+void test_intersect_bbox_rounding() {
+  AABB2<PointLL> world_box{-180,-90,180,90};
+  Tiles<PointLL> t(world_box, 0.25, 5);
+
+  AABB2<PointLL> single_box{0.5, 0.5, 0.501, 0.501};
+  auto intersection = t.Intersect(single_box);
+  if (intersection.size() != 1) {
+    throw std::runtime_error("Expected one tile returned from intersection, but got " + std::to_string(intersection.size()) + " instead.");
+  }
+  auto bins = intersection.begin()->second;
+  // expect only the lower left bin, 0
+  if (bins.size() != 1) {
+    throw std::runtime_error("Expected a single bin, but got " + std::to_string(bins.size()) + " bins.");
+  }
+  auto bin_id = *bins.begin();
+  if (bin_id != 0) {
+    throw std::runtime_error("Expected bin ID 0, but got " + std::to_string(bin_id) + " instead.");
+  }
+}
+
 }
 
 int main() {
@@ -428,6 +448,7 @@ int main() {
 
   suite.test(TEST_CASE(test_intersect_bbox_world));
   suite.test(TEST_CASE(test_intersect_bbox_single));
+  suite.test(TEST_CASE(test_intersect_bbox_rounding));
 
   return suite.tear_down();
 }


### PR DESCRIPTION
This issue cropped up where a bounding box which actually only intersected one tile was being detected as intersecting two. This was happening because the division was resulting in a number like `1809.99988`, which was (correctly) being `floor`ed to `1809` although the expected result was `1810`.

Added test for the same.

@kevinkreiser could you take a look, please?